### PR TITLE
TI-#112: Add timeRelative flag to initialization of day names

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -1512,7 +1512,7 @@ bool Datetime::initializeDayName (Pig& pig)
         time_t now = time (nullptr);
         struct tm* t = localtime (&now);
 
-        if (t->tm_wday >= day)
+        if (t->tm_wday >= day && timeRelative)
           t->tm_mday += day - t->tm_wday + 7;
         else
           t->tm_mday += day - t->tm_wday;


### PR DESCRIPTION
This fixes https://github.com/GothenburgBitFactory/timewarrior/issues/112. Timewarrior requires dates to be in the past.