### PR TITLE
Use safe functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set (HAVE_CMAKE true)
 project (shared)
 include (CXXSniffer)
 
+include (CheckFunctionExists)
+
 set (PROJECT_VERSION "1.0.0")
 
 set (PACKAGE "${PROJECT_NAME}")
@@ -15,6 +17,8 @@ set (PACKAGE_NAME "${PACKAGE}")
 set (PACKAGE_TARNAME "${PACKAGE}")
 set (PACKAGE_VERSION "${VERSION}")
 set (PACKAGE_STRING "${PACKAGE} ${VERSION}")
+
+check_function_exists(strlcpy HAVE_STRLCPY)
 
 message ("-- Configuring cmake.h")
 configure_file (

--- a/cmake.h.in
+++ b/cmake.h.in
@@ -30,6 +30,9 @@
 /* Found st.st_birthtime struct member */
 #cmakedefine HAVE_ST_BIRTHTIME
 
+/* Found strlcpy() */
+#cmakedefine HAVE_STRLCPY
+
 /* Functions */
 #cmakedefine HAVE_GET_CURRENT_DIR_NAME
 #cmakedefine HAVE_TIMEGM

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -266,7 +266,11 @@ std::string formatTime (time_t seconds)
   else if (seconds >= 3600)        snprintf (formatted, sizeof(formatted), "%d h",   (int) (seconds / 3600));
   else if (seconds >= 60)          snprintf (formatted, sizeof(formatted), "%d m",   (int) (seconds / 60));
   else if (seconds >= 1)           snprintf (formatted, sizeof(formatted), "%d s",   (int) seconds);
+#ifdef HAVE_STRLCPY
+  else                             strlcpy (formatted, "-", sizeof(formatted));
+#else
   else                             strcpy (formatted, "-");
+#endif /* HAVE_STRLCPY */
 
   return std::string (formatted);
 }

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -244,10 +244,10 @@ std::string formatBytes (size_t bytes)
 {
   char formatted[24];
 
-       if (bytes >=  995000000) sprintf (formatted, "%.1f GiB", bytes / 1000000000.0);
-  else if (bytes >=     995000) sprintf (formatted, "%.1f MiB", bytes /    1000000.0);
-  else if (bytes >=        995) sprintf (formatted, "%.1f KiB", bytes /       1000.0);
-  else                          sprintf (formatted, "%d B",     (int)bytes);
+       if (bytes >=  995000000) snprintf (formatted, sizeof(formatted), "%.1f GiB", bytes / 1000000000.0);
+  else if (bytes >=     995000) snprintf (formatted, sizeof(formatted), "%.1f MiB", bytes /    1000000.0);
+  else if (bytes >=        995) snprintf (formatted, sizeof(formatted), "%.1f KiB", bytes /       1000.0);
+  else                          snprintf (formatted, sizeof(formatted), "%d B",     (int)bytes);
 
   return commify (formatted);
 }
@@ -259,13 +259,13 @@ std::string formatTime (time_t seconds)
   char formatted[24];
   float days = (float) seconds / 86400.0;
 
-       if (seconds >= 86400 * 365) sprintf (formatted, "%.1f y", (days / 365.0));
-  else if (seconds >= 86400 * 84)  sprintf (formatted, "%1d mo", (int) (days / 30));
-  else if (seconds >= 86400 * 13)  sprintf (formatted, "%d wk",  (int) (float) (days / 7.0));
-  else if (seconds >= 86400)       sprintf (formatted, "%d d",   (int) days);
-  else if (seconds >= 3600)        sprintf (formatted, "%d h",   (int) (seconds / 3600));
-  else if (seconds >= 60)          sprintf (formatted, "%d m",   (int) (seconds / 60));
-  else if (seconds >= 1)           sprintf (formatted, "%d s",   (int) seconds);
+       if (seconds >= 86400 * 365) snprintf (formatted, sizeof(formatted), "%.1f y", (days / 365.0));
+  else if (seconds >= 86400 * 84)  snprintf (formatted, sizeof(formatted), "%1d mo", (int) (days / 30));
+  else if (seconds >= 86400 * 13)  snprintf (formatted, sizeof(formatted), "%d wk",  (int) (float) (days / 7.0));
+  else if (seconds >= 86400)       snprintf (formatted, sizeof(formatted), "%d d",   (int) days);
+  else if (seconds >= 3600)        snprintf (formatted, sizeof(formatted), "%d h",   (int) (seconds / 3600));
+  else if (seconds >= 60)          snprintf (formatted, sizeof(formatted), "%d m",   (int) (seconds / 60));
+  else if (seconds >= 1)           snprintf (formatted, sizeof(formatted), "%d s",   (int) seconds);
   else                             strcpy (formatted, "-");
 
   return std::string (formatted);


### PR DESCRIPTION
Hi!

When I compile taskshell and friends on OpenBSD I get the following warnings:
```liblibshared.a(format.cpp.o): In function `formatTime(long long)':```
```....../taskshell/src/libshared/src/format.cpp:(.text+0x6840): warning: strcpy() is almost always misused, please use strlcpy()```
```liblibshared.a(format.cpp.o): In function `formatBytes(unsigned long)':
....../taskshell/src/libshared/src/format.cpp:(.text+0x6488): warning: sprintf() is often misused, please use snprintf()```
```[100%] Built target tasksh_executable```

Fixing `sprintf()` is a no-brainer, but `strlcpy()` requires that we check that it exists before use. To get `strlcpy()` into task warrior and the other tools, the `HAVE_STRLCPY` needs to be declared, tentatively like in this patch.
