### PR TITLE
Fix isIPv4Address() and datetime test

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -190,9 +190,7 @@ bool isIPv4Address (const std::string& input, std::string& address, int& port)
     if (isEOS (input, c))
     {
       address = input.substr (0, std::min (c, colon));
-      if (isEOS (input, colon))
-        port = 0;
-      else
+      port = 0;
         port = std::stoi (input.substr (colon + 1));
 
       return true;

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -190,7 +190,9 @@ bool isIPv4Address (const std::string& input, std::string& address, int& port)
     if (isEOS (input, c))
     {
       address = input.substr (0, std::min (c, colon));
-      if (! isEOS (input, colon))
+      if (isEOS (input, colon))
+        port = 0;
+      else
         port = std::stoi (input.substr (colon + 1));
 
       return true;

--- a/test/datetime.t.cpp
+++ b/test/datetime.t.cpp
@@ -92,7 +92,7 @@ void testParseError (
 ////////////////////////////////////////////////////////////////////////////////
 int main (int, char**)
 {
-  UnitTest t (2088);
+  UnitTest t (2109);
 
   Datetime iso;
   std::string::size_type start = 0;


### PR DESCRIPTION
* isIPv4Address() didn't correctly set the port to zero and causes test fails
* the number of tests in datatime.t needs update