### PR TITLE
Ensure port is set to '0' if no port is given with IP4 address

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -192,7 +192,8 @@ bool isIPv4Address (const std::string& input, std::string& address, int& port)
       port = 0;
       if (! isEOS (input, colon))
         port = std::stoi (input.substr (colon + 1));
-
+      else
+        port = 0;
       return true;
     }
   }

--- a/test/shared.t.cpp
+++ b/test/shared.t.cpp
@@ -377,7 +377,7 @@ int main (int, char**)
 
   // Test IPv4/IPv6 address parsing.
   std::string address;
-  int port;
+  int port = 3;
   input = "127.0.0.1";
   t.ok    (isIPv4Address (input, address, port),           "isIPv4Address " + input + " --> yes");
   t.is    (address, "127.0.0.1",                           "isIPv4Address " + input + " --> address correct");


### PR DESCRIPTION
When an IP address with no port is given, the port is not set in `isIPv4Address`. This fix explicitly sets it to `0` in this case.