### PR TITLE
Make initializeMonth adhere to timeRelative flag

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -1555,8 +1555,10 @@ bool Datetime::initializeMonthName (Pig& pig)
         time_t now = time (nullptr);
         struct tm* t = localtime (&now);
 
-        if (t->tm_mon >= month)
+        if (t->tm_mon >= month && timeRelative)
+        {
           t->tm_year++;
+        }
 
         t->tm_mon = month;
         t->tm_mday = 1;

--- a/test/datetime.t.cpp
+++ b/test/datetime.t.cpp
@@ -1111,15 +1111,46 @@ int main (int, char**)
     testParse      (t, "mon");
     testParseError (t, "mon:");
 
-    // Verify Datetime::timeRelative is working as expected.
-    Datetime::timeRelative = true;
-    Datetime today;
-    Datetime r38 ("0:00:01");
-    t.notok (today.sameDay (r38), "Datetime::timeRelative=true 0:00:01 --> tomorrow");
-    Datetime::timeRelative = false;
-    Datetime r39 ("0:00:01");
-    t.ok (today.sameDay (r39), "Datetime::timeRelative=false 0:00:01 --> today");
-    Datetime::timeRelative = true;
+    {
+      // Verify Datetime::timeRelative is working as expected.
+      Datetime::timeRelative = true;
+      Datetime today;
+      Datetime r38("0:00:01");
+      t.notok(today.sameDay(r38), "Datetime::timeRelative=true 0:00:01 --> tomorrow");
+      Datetime::timeRelative = false;
+      Datetime r39("0:00:01");
+      t.ok(today.sameDay(r39), "Datetime::timeRelative=false 0:00:01 --> today");
+      Datetime::timeRelative = true;
+    }
+
+    {
+      // Verify Datetime::timeRelative=true puts months before and including current month into next year
+      Datetime::timeRelative = true;
+
+      Datetime today;
+
+      for (auto& month: {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"})
+      {
+        auto test = Datetime(month);
+        bool is_after = (test.month() > today.month());
+        std::string message = "Datetime::timeRelative=true --> " + std::string(month) + " in " + (is_after ? "same" : "next") + " year";
+        t.ok(test.year() == today.year() + (is_after ? 0 : 1), message);
+      }
+    }
+
+    {
+      // Verify Datetime::timeRelative=false puts months into current year
+      Datetime::timeRelative = false;
+
+      Datetime today;
+
+      for (auto& month: {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"})
+      {
+        auto test = Datetime(month);
+        std::string message = "Datetime::timeRelative=false --> " + std::string(month) + " in same year";
+        t.ok(test.year() == today.year(), message);
+      }
+    }
 
     // This is just a diagnostic dump of all named dates, and is used to verify
     // correctness manually.


### PR DESCRIPTION
When true, it puts months before and including current month into next year
When false, it puts months always into current year

This should fix https://github.com/GothenburgBitFactory/timewarrior/issues/228