### PR TITLE
Fix parsing of weekday names to dates

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -1518,25 +1518,11 @@ bool Datetime::initializeDayName (Pig& pig)
 
         if (t->tm_wday >= day)
         {
-          if (timeRelative)
-          {
-            t->tm_mday += day - t->tm_wday + 7;
-          }
-          else
-          {
-            t->tm_mday += day - t->tm_wday;
-          }
+          t->tm_mday += day - t->tm_wday + (timeRelative ? 7 : 0);
         }
-        else if (t->tm_wday < day)
+        else
         {
-          if (timeRelative)
-          {
-            t->tm_mday += day - t->tm_wday;
-          }
-          else
-          {
-            t->tm_mday += day - t->tm_wday - 7;
-          }
+          t->tm_mday += day - t->tm_wday - (timeRelative ? 0 : 7);
         }
 
         t->tm_hour = t->tm_min = t->tm_sec = 0;

--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -1516,10 +1516,28 @@ bool Datetime::initializeDayName (Pig& pig)
         time_t now = time (nullptr);
         struct tm* t = localtime (&now);
 
-        if (t->tm_wday >= day && timeRelative)
-          t->tm_mday += day - t->tm_wday + 7;
-        else
-          t->tm_mday += day - t->tm_wday;
+        if (t->tm_wday >= day)
+        {
+          if (timeRelative)
+          {
+            t->tm_mday += day - t->tm_wday + 7;
+          }
+          else
+          {
+            t->tm_mday += day - t->tm_wday;
+          }
+        }
+        else if (t->tm_wday < day)
+        {
+          if (timeRelative)
+          {
+            t->tm_mday += day - t->tm_wday;
+          }
+          else
+          {
+            t->tm_mday += day - t->tm_wday - 7;
+          }
+        }
 
         t->tm_hour = t->tm_min = t->tm_sec = 0;
         t->tm_isdst = -1;

--- a/test/datetime.t.cpp
+++ b/test/datetime.t.cpp
@@ -613,45 +613,45 @@ int main (int, char**)
 
       Datetime r4 ("sunday");
       if (now.dayOfWeek () >= 0)
-        t.ok (r4.sameDay (now + (0 - now.dayOfWeek () + 7) * 86400), "next sunday");
+        t.ok (r4.sameDay (now + (0 - now.dayOfWeek () + 7) * 86400), "sunday -> next sunday");
       else
-        t.ok (r4.sameDay (now + (0 - now.dayOfWeek ()) * 86400), "next sunday");;
+        t.ok (r4.sameDay (now + (0 - now.dayOfWeek ()) * 86400), "sunday -> next sunday");;
 
       Datetime r5 ("monday");
       if (now.dayOfWeek () >= 1)
-        t.ok (r5.sameDay (now + (1 - now.dayOfWeek () + 7) * 86400), "next monday");
+        t.ok (r5.sameDay (now + (1 - now.dayOfWeek () + 7) * 86400), "monday -> next monday");
       else
-        t.ok (r5.sameDay (now + (1 - now.dayOfWeek ()) * 86400), "next monday");;
+        t.ok (r5.sameDay (now + (1 - now.dayOfWeek ()) * 86400), "monday -> next monday");;
 
       Datetime r6 ("tuesday");
       if (now.dayOfWeek () >= 2)
-        t.ok (r6.sameDay (now + (2 - now.dayOfWeek () + 7) * 86400), "next tuesday");
+        t.ok (r6.sameDay (now + (2 - now.dayOfWeek () + 7) * 86400), "tuesday -> next tuesday");
       else
-        t.ok (r6.sameDay (now + (2 - now.dayOfWeek ()) * 86400), "next tuesday");;
+        t.ok (r6.sameDay (now + (2 - now.dayOfWeek ()) * 86400), "tuesday -> next tuesday");;
 
       Datetime r7 ("wednesday");
       if (now.dayOfWeek () >= 3)
-        t.ok (r7.sameDay (now + (3 - now.dayOfWeek () + 7) * 86400), "next wednesday");
+        t.ok (r7.sameDay (now + (3 - now.dayOfWeek () + 7) * 86400), "wednesday -> next wednesday");
       else
-        t.ok (r7.sameDay (now + (3 - now.dayOfWeek ()) * 86400), "next wednesday");;
+        t.ok (r7.sameDay (now + (3 - now.dayOfWeek ()) * 86400), "wednesday -> next wednesday");;
 
       Datetime r8 ("thursday");
       if (now.dayOfWeek () >= 4)
-        t.ok (r8.sameDay (now + (4 - now.dayOfWeek () + 7) * 86400), "next thursday");
+        t.ok (r8.sameDay (now + (4 - now.dayOfWeek () + 7) * 86400), "thursday -> next thursday");
       else
-        t.ok (r8.sameDay (now + (4 - now.dayOfWeek ()) * 86400), "next thursday");;
+        t.ok (r8.sameDay (now + (4 - now.dayOfWeek ()) * 86400), "thursday -> next thursday");;
 
       Datetime r9 ("friday");
       if (now.dayOfWeek () >= 5)
-        t.ok (r9.sameDay (now + (5 - now.dayOfWeek () + 7) * 86400), "next friday");
+        t.ok (r9.sameDay (now + (5 - now.dayOfWeek () + 7) * 86400), "friday -> next friday");
       else
-        t.ok (r9.sameDay (now + (5 - now.dayOfWeek ()) * 86400), "next friday");;
+        t.ok (r9.sameDay (now + (5 - now.dayOfWeek ()) * 86400), "friday -> next friday");;
 
       Datetime r10 ("saturday");
       if (now.dayOfWeek () >= 6)
-        t.ok (r10.sameDay (now + (6 - now.dayOfWeek () + 7) * 86400), "next saturday");
+        t.ok (r10.sameDay (now + (6 - now.dayOfWeek () + 7) * 86400), "saturday -> next saturday");
       else
-        t.ok (r10.sameDay (now + (6 - now.dayOfWeek ()) * 86400), "next saturday");;
+        t.ok (r10.sameDay (now + (6 - now.dayOfWeek ()) * 86400), "saturday -> next saturday");;
     }
 
     // Relative dates - look back
@@ -662,25 +662,46 @@ int main (int, char**)
       t.ok (r1.sameDay (now), "today = now");
 
       Datetime r4 ("sunday");
-      t.ok (r4.sameDay (now + (0 - now.dayOfWeek ()) * 86400), "previous sunday");
+      if (now.dayOfWeek () >= 0)
+        t.ok (r4.sameDay (now + (0 - now.dayOfWeek ()) * 86400), "sunday -> previous sunday" );
+      else
+        t.ok (r4.sameDay (now + (0 - now.dayOfWeek () - 7) * 86400), "sunday -> previous sunday");
 
       Datetime r5 ("monday");
-      t.ok (r5.sameDay (now + (1 - now.dayOfWeek ()) * 86400), "previous monday");
+      if (now.dayOfWeek () >= 1)
+        t.ok (r5.sameDay (now + (1 - now.dayOfWeek ()) * 86400), "monday -> previous monday");
+      else
+        t.ok (r5.sameDay (now + (1 - now.dayOfWeek () - 7) * 86400), "monday -> previous monday");
 
       Datetime r6 ("tuesday");
-      t.ok (r6.sameDay (now + (2 - now.dayOfWeek ()) * 86400), "previous tuesday");
+      if (now.dayOfWeek () >= 2)
+        t.ok (r6.sameDay (now + (2 - now.dayOfWeek ()) * 86400), "tuesday -> previous tuesday");
+      else
+        t.ok (r6.sameDay (now + (2 - now.dayOfWeek () - 7) * 86400), "tuesday -> previous tuesday");
 
       Datetime r7 ("wednesday");
-      t.ok (r7.sameDay (now + (3 - now.dayOfWeek ()) * 86400), "previous wednesday");
+      if (now.dayOfWeek () >= 3)
+        t.ok (r7.sameDay (now + (3 - now.dayOfWeek ()) * 86400), "wednesday -> previous wednesday");
+      else
+        t.ok (r7.sameDay (now + (3 - now.dayOfWeek () - 7) * 86400), "wednesday -> previous wednesday");
 
       Datetime r8 ("thursday");
-      t.ok (r8.sameDay (now + (4 - now.dayOfWeek ()) * 86400), "previous thursday");
+      if (now.dayOfWeek () >= 4)
+        t.ok (r8.sameDay (now + (4 - now.dayOfWeek ()) * 86400), "thursday -> previous thursday");
+      else
+        t.ok (r8.sameDay (now + (4 - now.dayOfWeek () - 7) * 86400), "thursday -> previous thursday");
 
       Datetime r9 ("friday");
-      t.ok (r9.sameDay (now + (5 - now.dayOfWeek ()) * 86400), "previous friday");
+      if (now.dayOfWeek () >= 5)
+        t.ok (r9.sameDay (now + (5 - now.dayOfWeek ()) * 86400), "friday -> previous friday");
+      else
+        t.ok (r9.sameDay (now + (5 - now.dayOfWeek () - 7) * 86400), "friday -> previous friday");
 
       Datetime r10 ("saturday");
-      t.ok (r10.sameDay (now + (6 - now.dayOfWeek ()) * 86400), "previous saturday");
+      if (now.dayOfWeek () >= 6)
+        t.ok (r10.sameDay (now + (6 - now.dayOfWeek ()) * 86400), "saturday -> previous saturday");
+      else
+        t.ok (r10.sameDay (now + (6 - now.dayOfWeek () - 7) * 86400), "saturday -> previous saturday");
     }
 
     Datetime r11 ("eow");


### PR DESCRIPTION
Fixes an error in the conversion of weekday names into a date in respect of Timewarrior's need to get a date in the past.

Fixes https://github.com/GothenburgBitFactory/timewarrior/issues/194