### PR TITLE
File::copy () should return false on I/O errors

### DIFF
--- a/src/FS.cpp
+++ b/src/FS.cpp
@@ -822,14 +822,14 @@ bool File::remove (const std::string& name)
 ////////////////////////////////////////////////////////////////////////////////
 bool File::copy (const std::string& from, const std::string& to)
 {
-  // 'from' must exist.
-  if (! access (from.c_str (), F_OK))
-  {
-    std::ifstream src (from, std::ios::binary);
-    std::ofstream dst (to,   std::ios::binary);
+  std::ifstream src (from, std::ios::binary);
 
+  if (! src.fail ())
+  {
+    std::ofstream dst (to,   std::ios::binary);
     dst << src.rdbuf ();
-    return true;
+    dst.close ();
+    return dst.good () && ! src.bad ();
   }
 
   return false;

--- a/test/fs.t.cpp
+++ b/test/fs.t.cpp
@@ -33,7 +33,7 @@
 
 int main (int, char**)
 {
-  UnitTest t (120);
+  UnitTest t (125);
 
   try
   {
@@ -176,6 +176,14 @@ int main (int, char**)
     t.notok (m & S_IXOTH,                  "File::mode tmp/file.t.perm.txt --------x good");
     f8.remove ();
     t.notok (f8.exists (),                 "File::remove perm file no longer exists");
+
+    File::write ("tmp/file.t.txt", "This is a test\n");
+    t.ok (File::copy ("tmp/file.t.txt", "tmp/file.t.copy.txt"), "File::copy returned true");
+    File f9 ("tmp/file.t.copy.txt");
+    t.ok (f9.exists (),     "File::copy created copy");
+    t.ok (f9.size () == 15, "File::copy tmp/file.t.copy.txt good after copy");
+    t.notok (File::copy ("tmp/does-not-exits.txt", "tmp/should-not-exists.txt"), "File::copy returns false if not exists");
+    t.notok (File ("tmp/should-not-exists.txt").exists (), "File::copy destination should not exist");
 
     tmp.remove ();
     t.notok (tmp.exists (),                "tmp dir removed.");


### PR DESCRIPTION
File::copy would return true even if it was unable to actually copy the
data from the source file to the destination file.

This function also does not need a separate access check since ifstream will
already set the fail bit if something went wrong with the open.

GothenburgBitFactory/timewarrior#155