### PR TITLE
support recursive creation of directories

### DIFF
--- a/src/FS.cpp
+++ b/src/FS.cpp
@@ -889,7 +889,15 @@ bool Directory::create (int mode /* = 0755 */)
 {
   // No error handling because we want failure to be silent, somewhat emulating
   // "mkdir -p".
-  return mkdir (_data.c_str (), mode) == 0 ? true : false;
+  Directory parent_dir = parent ();
+  if (! parent_dir.exists ())
+  {
+      if (! parent_dir.create (mode))
+      {
+          return false;
+      }
+  }
+  return mkdir (_data.c_str (), mode) == 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While testing my changes in https://github.com/GothenburgBitFactory/taskwarrior/pull/2316 , I noticed that taskwarrior failed to create the proper directory if its parent directory didn't exist.

All comments, alternatives and improvement suggestions welcome.