### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/src/FS.cpp
+++ b/src/FS.cpp
@@ -475,10 +475,10 @@ bool File::lock ()
   _locked = false;
   if (_fh && _h != -1)
   {
-#ifdef DARWIN
+#if defined(DARWIN)
                     // l_start l_len l_pid l_type   l_whence
     struct flock fl = {0,      0,    0,    F_WRLCK, SEEK_SET};
-#elif FREEBSD
+#elif defined(FREEBSD)
                     // l_type   l_whence  l_start  l_len  l_pid  l_sysid
     struct flock fl = {F_WRLCK, SEEK_SET, 0,       0,     0,     0 };
 #else
@@ -498,10 +498,10 @@ void File::unlock ()
 {
   if (_locked)
   {
-#ifdef DARWIN
+#if defined(DARWIN)
                     // l_start l_len l_pid l_type   l_whence
     struct flock fl = {0,      0,    0,    F_WRLCK, SEEK_SET};
-#elif FREEBSD
+#elif defined(FREEBSD)
                     // l_type   l_whence  l_start  l_len  l_pid  l_sysid
     struct flock fl = {F_WRLCK, SEEK_SET, 0,       0,     0,     0 };
 #else


### PR DESCRIPTION
This fixes a compilation issue with Timewarrior on FreeBSD (see https://github.com/GothenburgBitFactory/timewarrior/issues/258). Patch supplied by @silent-at-gh