### PR TITLE
execute: Write an error to stderr if execution fails

### DIFF
--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -700,7 +700,9 @@ int execute (
       argv[i+1] = (char*) args[i].c_str ();
 
     argv[args.size () + 1] = NULL;
-    _exit (execvp (executable.c_str (), argv));
+    int rc = execvp (executable.c_str (), argv);
+    std::cerr << "Failed to execute '" << executable << "' Error: " << strerror (errno) << '\n';
+    _exit (rc);
   }
 
   // This is only reached in the parent


### PR DESCRIPTION
In timewarrior, I had a broken link to an extension. The result was that
the report would fail without output (but a -1 return code).

This change allows some more context to be printed about why the run
failed (file missing, not executable, etc..)

Related to GothenburgBitFactory/timewarrior#367

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>