### PR TITLE
Switch to C++17.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required (VERSION 3.1)
-set (CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set (HAVE_CMAKE true)
 # https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.1)
 set (CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake >= 2.8.4 is required
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set (HAVE_CMAKE true)
+# https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
+set(CMAKE_CXX_STANDARD 17)
 
 project (shared)
 include (CXXSniffer)
@@ -29,4 +31,3 @@ add_subdirectory (src)
 if (EXISTS ${CMAKE_SOURCE_DIR}/test)
   add_subdirectory (test EXCLUDE_FROM_ALL)
 endif (EXISTS ${CMAKE_SOURCE_DIR}/test)
-

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ master/HEAD
 - Corrected initialization order of struct flock for DARWIN. This may address
   file locking prboelms on MacOS.
 - Libshared now supports datetime values up to year 9999.
+- Bump minimal required standard to C++17 and minimal cmake version to 3.1.
 
 tasksh-1.2.0 (2017-05-10)
 

--- a/cmake/CXXSniffer.cmake
+++ b/cmake/CXXSniffer.cmake
@@ -1,30 +1,10 @@
-message ("-- Configuring C++11")
 message ("-- System: ${CMAKE_SYSTEM_NAME}")
-
-include (CheckCXXCompilerFlag)
-
-# NOTE: Phase out -std=gnu++0x and --std=c++0x as soon as realistically possible.
-CHECK_CXX_COMPILER_FLAG("-std=c++11"   _HAS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x"   _HAS_CXX0X)
-CHECK_CXX_COMPILER_FLAG("-std=gnu++0x" _HAS_GNU0X)
-
-if (_HAS_CXX11)
-  set (_CXX11_FLAGS "-std=c++11")
-elseif (_HAS_CXX0X)
-  message (WARNING "Enabling -std=c++0x draft compile flag. Your compiler does not support the standard '-std=c++11' option.  Consider upgrading.")
-  set (_CXX11_FLAGS "-std=c++0x")
-elseif (_HAS_GNU0X)
-  message (WARNING "Enabling -std=gnu++0x draft compile flag. Your compiler does not support the standard '-std=c++11' option. Consider upgrading.")
-  set (_CXX11_FLAGS "-std=gnu++0x")
-else (_HAS_CXX11)
- message (FATAL_ERROR "C++11 support missing. Try upgrading your C++ compiler. If you have a good reason for using an outdated compiler, please let us know at support@gothenburgbitfactory.org.")
-endif (_HAS_CXX11)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set (LINUX true)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set (DARWIN true)
-  set (_CXX11_FLAGS "${_CXX11_FLAGS} -stdlib=libc++")
+  set (CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "kFreeBSD")
   set (KFREEBSD true)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
@@ -41,13 +21,8 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "GNU")
   set (GNUHURD true)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "CYGWIN")
   set (CYGWIN true)
-  # NOTE: Not setting -std=gnu++0x leads to compile errors even with
-  #       GCC 4.8.3, and debugging those leads to insanity. Adding this
-  #       workaround instead of fixing Cygwin.
-  set (_CXX11_FLAGS "-std=gnu++0x")
 else (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set (UNKNOWN true)
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-set (CMAKE_CXX_FLAGS "${_CXX11_FLAGS} ${CMAKE_CXX_FLAGS}")
 set (CMAKE_CXX_FLAGS "-Wall -Wextra -Wsign-compare -Wreturn-type ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
C++17 is partially available since GCC5 (released in 2015) and default
since GCC11 (released in April 2021). TaskWarrior requires C++17 as
well. However TimeWarrior documentation says C++14 is enough.

CXX_STANDARD_REQUIRED is not set so it should try to fall back to whatever
standard is available.

Also requires bumping minimum cmake version to 3.1 (released in 2018).