### PR TITLE
clang-tidy: use single character '' for find

### DIFF
--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -222,7 +222,7 @@ std::string Table::render ()
     out += extra;
 
     // Trim right.
-    out.erase (out.find_last_not_of (" ") + 1);
+    out.erase (out.find_last_not_of (' ') + 1);
     out += '\n';
 
     // Stop if the line limit is exceeded.
@@ -304,7 +304,7 @@ std::string Table::render ()
       out += (oddness ? extra_odd : extra_even);
 
       // Trim right.
-      out.erase (out.find_last_not_of (" ") + 1);
+      out.erase (out.find_last_not_of (' ') + 1);
       out += '\n';
 
       // Stop if the line limit is exceeded.

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -277,19 +277,19 @@ std::string printable (const std::string& input)
   // Sanitize 'message'.
   std::string sanitized = input;
   std::string::size_type bad;
-  while ((bad = sanitized.find ("\r")) != std::string::npos)
+  while ((bad = sanitized.find ('\r')) != std::string::npos)
     sanitized.replace (bad, 1, "\\r");
 
-  while ((bad = sanitized.find ("\n")) != std::string::npos)
+  while ((bad = sanitized.find ('\n')) != std::string::npos)
     sanitized.replace (bad, 1, "\\n");
 
-  while ((bad = sanitized.find ("\f")) != std::string::npos)
+  while ((bad = sanitized.find ('\f')) != std::string::npos)
     sanitized.replace (bad, 1, "\\f");
 
-  while ((bad = sanitized.find ("\t")) != std::string::npos)
+  while ((bad = sanitized.find ('\t')) != std::string::npos)
     sanitized.replace (bad, 1, "\\t");
 
-  while ((bad = sanitized.find ("\v")) != std::string::npos)
+  while ((bad = sanitized.find ('\v')) != std::string::npos)
     sanitized.replace (bad, 1, "\\v");
 
   return sanitized;


### PR DESCRIPTION
Faster.

Found with performance-faster-string-find

Signed-off-by: Rosen Penev <rosenp@gmail.com>