### PR TITLE
clang-tidy: run through all performance checks

### DIFF
--- a/src/Composite.cpp
+++ b/src/Composite.cpp
@@ -85,7 +85,7 @@ std::string Composite::str () const
   std::vector <int> colors;
   for (unsigned int layer = 0; layer < _layers.size (); ++layer)
   {
-    auto text   = std::get <0> (_layers[layer]);
+    const auto& text   = std::get <0> (_layers[layer]);
     auto offset = std::get <1> (_layers[layer]);
     auto len    = utf8_text_length (text);
 

--- a/src/Packrat.cpp
+++ b/src/Packrat.cpp
@@ -92,7 +92,7 @@ void Packrat::external (
 bool Packrat::matchRule (
   const std::string& rule,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -111,7 +111,7 @@ bool Packrat::matchRule (
 bool Packrat::matchProduction (
   const PEG::Production& production,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -134,7 +134,7 @@ bool Packrat::matchProduction (
 
   // On success transfer all sub-branches.
   for (auto& b : collector->_branches)
-    for (auto sub : b->_branches)
+    for (const auto& sub : b->_branches)
       parseTree->addBranch (sub);
 
   return true;
@@ -145,7 +145,7 @@ bool Packrat::matchProduction (
 bool Packrat::matchTokenQuant (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -216,7 +216,7 @@ bool Packrat::matchTokenQuant (
 bool Packrat::matchTokenLookahead (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -255,7 +255,7 @@ bool Packrat::matchTokenLookahead (
 bool Packrat::matchToken (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -314,7 +314,7 @@ bool Packrat::matchToken (
 bool Packrat::matchIntrinsic (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -638,7 +638,7 @@ bool Packrat::matchIntrinsic (
 bool Packrat::matchCharLiteral (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)
@@ -677,7 +677,7 @@ bool Packrat::matchCharLiteral (
 bool Packrat::matchStringLiteral (
   const PEG::Token& token,
   Pig& pig,
-  std::shared_ptr <Tree> parseTree,
+  const std::shared_ptr <Tree>& parseTree,
   int indent)
 {
   if (_debug > 1)

--- a/src/Packrat.h
+++ b/src/Packrat.h
@@ -43,14 +43,14 @@ public:
   std::string dump () const;
 
 private:
-  bool matchRule           (const std::string&,     Pig&, std::shared_ptr <Tree>, int);
-  bool matchProduction     (const PEG::Production&, Pig&, std::shared_ptr <Tree>, int);
-  bool matchTokenQuant     (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
-  bool matchTokenLookahead (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
-  bool matchToken          (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
-  bool matchIntrinsic      (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
-  bool matchCharLiteral    (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
-  bool matchStringLiteral  (const PEG::Token&,      Pig&, std::shared_ptr <Tree>, int);
+  bool matchRule           (const std::string&,     Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchProduction     (const PEG::Production&, Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchTokenQuant     (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchTokenLookahead (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchToken          (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchIntrinsic      (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchCharLiteral    (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
+  bool matchStringLiteral  (const PEG::Token&,      Pig&, const std::shared_ptr <Tree>&, int);
 
   bool canonicalize (std::string&, const std::string&, const std::string&) const;
 

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -39,7 +39,7 @@
 //  - The destructor will delete all branches recursively.
 //  - Tree::enumerate is a snapshot, and is invalidated by modification.
 //  - Branch sequence is preserved.
-void Tree::addBranch (std::shared_ptr <Tree> branch)
+void Tree::addBranch (const std::shared_ptr <Tree>& branch)
 {
   if (! branch)
     throw "Failed to allocate memory for parse tree.";
@@ -48,7 +48,7 @@ void Tree::addBranch (std::shared_ptr <Tree> branch)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void Tree::removeBranch (std::shared_ptr <Tree> branch)
+void Tree::removeBranch (const std::shared_ptr <Tree>& branch)
 {
   for (auto i = _branches.begin (); i != _branches.end (); ++i)
   {
@@ -67,7 +67,7 @@ void Tree::removeAllBranches ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void Tree::replaceBranch (std::shared_ptr <Tree> from, std::shared_ptr <Tree> to)
+void Tree::replaceBranch (const std::shared_ptr <Tree>& from, const std::shared_ptr <Tree>& to)
 {
   for (unsigned int i = 0; i < _branches.size (); ++i)
   {
@@ -213,7 +213,7 @@ std::shared_ptr <Tree> Tree::find (const std::string& path)
 
 ////////////////////////////////////////////////////////////////////////////////
 std::string Tree::dumpNode (
-  const std::shared_ptr <Tree> t,
+  const std::shared_ptr <Tree>& t,
   int depth) const
 {
   std::stringstream out;

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -37,10 +37,10 @@ class Tree;
 class Tree
 {
 public:
-  void addBranch (std::shared_ptr <Tree>);
-  void removeBranch (std::shared_ptr <Tree>);
+  void addBranch (const std::shared_ptr <Tree>&);
+  void removeBranch (const std::shared_ptr <Tree>&);
   void removeAllBranches ();
-  void replaceBranch (std::shared_ptr <Tree>, std::shared_ptr <Tree>);
+  void replaceBranch (const std::shared_ptr <Tree>&, const std::shared_ptr <Tree>&);
 
   void attribute (const std::string&, const std::string&);
   void attribute (const std::string&, const int);
@@ -62,7 +62,7 @@ public:
   std::string dump () const;
 
 private:
-  std::string dumpNode (const std::shared_ptr <Tree>, int) const;
+  std::string dumpNode (const std::shared_ptr <Tree>&, int) const;
 
 public:
   std::string                          _name       {"Unknown"};  // Name.


### PR DESCRIPTION
Some of them it does not fix automatically.

Signed-off-by: Rosen Penev <rosenp@gmail.com>