### PR TITLE
manual const ref conversions

### DIFF
--- a/src/Packrat.cpp
+++ b/src/Packrat.cpp
@@ -79,7 +79,7 @@ void Packrat::entity (const std::string& category, const std::string& name)
 ////////////////////////////////////////////////////////////////////////////////
 void Packrat::external (
   const std::string& rule,
-  bool (*fn)(Pig&, std::shared_ptr <Tree>))
+  bool (*fn)(Pig&, const std::shared_ptr <Tree>&))
 {
   if (_externals.find (rule) != _externals.end ())
     throw format ("There is already an external parser defined for rule '{1}'.", rule);

--- a/src/Packrat.h
+++ b/src/Packrat.h
@@ -37,7 +37,7 @@ class Packrat
 public:
   void parse (const PEG&, const std::string&);
   void entity (const std::string&, const std::string&);
-  void external (const std::string&, bool (*)(Pig&, std::shared_ptr <Tree>));
+  void external (const std::string&, bool (*)(Pig&, const std::shared_ptr <Tree>&));
 
   void debug ();
   std::string dump () const;
@@ -62,7 +62,7 @@ private:
   std::map <std::string, PEG::Rule>                              _syntax   {};
   std::shared_ptr <Tree>                                         _tree     {std::make_shared <Tree> ()};
   std::multimap <std::string, std::string>                       _entities {};
-  std::map <std::string, bool (*)(Pig&, std::shared_ptr <Tree>)> _externals {};
+  std::map <std::string, bool (*)(Pig&, const std::shared_ptr <Tree>&)> _externals {};
 };
 
 #endif

--- a/test/external.t.cpp
+++ b/test/external.t.cpp
@@ -33,7 +33,7 @@
 #include <Tree.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-bool externalParser (Pig& pig, std::shared_ptr <Tree> branch)
+bool externalParser (Pig& pig, const std::shared_ptr <Tree>& branch)
 {
   if (pig.skipLiteral ("foo"))
   {


### PR DESCRIPTION
clang-tidy found these but was not able to automatically fix them.

Signed-off-by: Rosen Penev <rosenp@gmail.com>