### PR TITLE
clang-tidy: add missing override

### DIFF
--- a/test/json.t.cpp
+++ b/test/json.t.cpp
@@ -105,19 +105,19 @@ std::stringstream combined;
 class EventSink : public json::SAX::Sink
 {
 public:
-  void eventDocStart ()                            { combined << "<doc>";                            }
-  void eventDocEnd ()                              { combined << "</doc>";                           }
-  void eventObjectStart ()                         { combined << "<object>";                         }
-  void eventObjectEnd (int)                        { combined << "</object>";                        }
-  void eventArrayStart ()                          { combined << "<array>";                          }
-  void eventArrayEnd (int)                         { combined << "</array>";                         }
-  void eventName (const std::string& value)        { combined << "<name>"   << value << "</name>";   }
-  void eventValueNull ()                           { combined << "<null />";                         }
-  void eventValueBool (bool value)                 { combined << "<bool>"   << value << "</bool>";   }
-  void eventValueInt (int64_t value)               { combined << "<int>"    << value << "</int>";    }
-  void eventValueUint (uint64_t value)             { combined << "<uint>"   << value << "</uint>";   }
-  void eventValueDouble (double value)             { combined << "<double>" << value << "</double>"; }
-  void eventValueString (const std::string& value) { combined << "<string>" << value << "</string>"; }
+  void eventDocStart () override                            { combined << "<doc>";                            }
+  void eventDocEnd () override                              { combined << "</doc>";                           }
+  void eventObjectStart () override                         { combined << "<object>";                         }
+  void eventObjectEnd (int) override                        { combined << "</object>";                        }
+  void eventArrayStart () override                          { combined << "<array>";                          }
+  void eventArrayEnd (int) override                         { combined << "</array>";                         }
+  void eventName (const std::string& value) override        { combined << "<name>"   << value << "</name>";   }
+  void eventValueNull () override                           { combined << "<null />";                         }
+  void eventValueBool (bool value) override                 { combined << "<bool>"   << value << "</bool>";   }
+  void eventValueInt (int64_t value) override               { combined << "<int>"    << value << "</int>";    }
+  void eventValueUint (uint64_t value) override             { combined << "<uint>"   << value << "</uint>";   }
+  void eventValueDouble (double value) override             { combined << "<double>" << value << "</double>"; }
+  void eventValueString (const std::string& value) override { combined << "<string>" << value << "</string>"; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/sax_test.cpp
+++ b/test/sax_test.cpp
@@ -33,17 +33,17 @@
 class EventSink : public json::SAX::Sink
 {
 public:
-  void eventObjectStart ()                         { std::cout << "# object start\n";                                 }
-  void eventObjectEnd (int count)                  { std::cout << "# object end (" << count << " items)\n";           }
-  void eventArrayStart ()                          { std::cout << "# array start\n";                                  }
-  void eventArrayEnd (int count)                   { std::cout << "# array end (" << count << " items)\n";            }
-  void eventName (const std::string& value)        { std::cout << "# name '" << value << "'\n";                       }
-  void eventValueNull ()                           { std::cout << "# value 'null'\n";                                 }
-  void eventValueBool (bool value)                 { std::cout << "# value '" << (value ? "true" : "false") << "'\n"; }
-  void eventValueInt (int64_t value)               { std::cout << "# value '" << value << "'\n";                      }
-  void eventValueUint (uint64_t value)             { std::cout << "# value '" << value << "'\n";                      }
-  void eventValueDouble (double value)             { std::cout << "# value '" << value << "'\n";                      }
-  void eventValueString (const std::string& value) { std::cout << "# value '" << value << "'\n";                      }
+  void eventObjectStart () override                         { std::cout << "# object start\n";                                 }
+  void eventObjectEnd (int count) override                  { std::cout << "# object end (" << count << " items)\n";           }
+  void eventArrayStart () override                          { std::cout << "# array start\n";                                  }
+  void eventArrayEnd (int count) override                   { std::cout << "# array end (" << count << " items)\n";            }
+  void eventName (const std::string& value) override        { std::cout << "# name '" << value << "'\n";                       }
+  void eventValueNull () override                           { std::cout << "# value 'null'\n";                                 }
+  void eventValueBool (bool value) override                 { std::cout << "# value '" << (value ? "true" : "false") << "'\n"; }
+  void eventValueInt (int64_t value) override               { std::cout << "# value '" << value << "'\n";                      }
+  void eventValueUint (uint64_t value) override             { std::cout << "# value '" << value << "'\n";                      }
+  void eventValueDouble (double value) override             { std::cout << "# value '" << value << "'\n";                      }
+  void eventValueString (const std::string& value) override { std::cout << "# value '" << value << "'\n";                      }
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>