### PR TITLE
clang-tidy: replace size comparisons with empty

### DIFF
--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -235,7 +235,7 @@ Color::Color (const std::string& spec)
         fg_value |= _COLOR_256;
       }
     }
-    else if (word != "")
+    else if (!word.empty())
       throw format ("The color '{1}' is not recognized.", word);
   }
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -333,7 +333,7 @@ void Configuration::set (const std::string& key, const std::string& value)
 // Autovivification is ok here.
 void Configuration::setIfBlank (const std::string& key, const std::string& value)
 {
-  if ((*this)[key] == "")
+  if ((*this)[key].empty())
   {
     (*this)[key] = value;
     _dirty = true;

--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -236,7 +236,7 @@ void Datetime::clear ()
 bool Datetime::parse_formatted (Pig& pig, const std::string& format)
 {
   // Short-circuit on missing format.
-  if (format == "")
+  if (format.empty())
     return false;
 
   auto checkpoint = pig.cursor ();

--- a/src/Duration.cpp
+++ b/src/Duration.cpp
@@ -307,7 +307,7 @@ bool Duration::parse_units (Pig& pig)
 
   // Static and so preserved between calls.
   static std::vector <std::string> units;
-  if (units.size () == 0)
+  if (units.empty())
     for (unsigned int i = 0; i < NUM_DURATIONS; i++)
       units.push_back (durations[i].unit);
 

--- a/src/FS.cpp
+++ b/src/FS.cpp
@@ -458,7 +458,7 @@ std::string File::removeBOM (const std::string& input)
 ////////////////////////////////////////////////////////////////////////////////
 bool File::open ()
 {
-  if (_data != "")
+  if (!_data.empty())
   {
     if (! _fh)
     {

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -61,7 +61,7 @@ void Log::write (const std::string& category, const std::string& line)
   if (_ignore.find (category) != _ignore.end ())
     return;
 
-  if (line != "")
+  if (!line.empty())
   {
     // If line contains newlines, split it into separate lines and log each one.
     if (line.find ('\n') != std::string::npos)
@@ -82,7 +82,7 @@ void Log::write (const std::string& category, const std::string& line)
       _prior = line;
 
       // Catch up by writing out the backlog.
-      if (_name != "" && _backlog.size ())
+      if (!_name.empty() && !_backlog.empty())
       {
         for (const auto& line : _backlog)
           _file.append (line); 
@@ -98,7 +98,7 @@ void Log::write (const std::string& category, const std::string& line)
                             + ' ' + format ("(Repeated {1} times)", _repetition)
                             + '\n';
 
-        if (_name != "")
+        if (!_name.empty())
           _file.append (message);
         else
           _backlog.push_back (message);
@@ -112,7 +112,7 @@ void Log::write (const std::string& category, const std::string& line)
                           + ' ' + line
                           + '\n';
 
-      if (_name != "")
+      if (!_name.empty())
         _file.append (message);
       else
         _backlog.push_back (message);

--- a/src/PEG.cpp
+++ b/src/PEG.cpp
@@ -89,10 +89,10 @@ void PEG::loadFromString (const std::string& input)
     line = trim (removeComment (line));
 
     // Skip blank lines with no semantics.
-    if (line == "" and rule_name == "")
+    if (line.empty() and rule_name.empty())
       continue;
 
-    if (line != "")
+    if (!line.empty())
     {
       int token_count = 0;
 
@@ -120,7 +120,7 @@ void PEG::loadFromString (const std::string& input)
           rule_name = token.substr (0, token.size () - 1);
 
           // If this is the first Rule, capture it as a starting point.
-          if (_start == "")
+          if (_start.empty())
             _start = rule_name;
 
           _rules[rule_name] = PEG::Rule ();
@@ -238,7 +238,7 @@ std::string PEG::dump () const
   out << "PEG\n";
 
   // Show the import files, if any.
-  if (_imports.size ())
+  if (!_imports.empty())
   {
     for (const auto& import : _imports)
       out << "  import " << import << '\n';
@@ -367,7 +367,7 @@ std::string PEG::removeComment (const std::string& line)
 ////////////////////////////////////////////////////////////////////////////////
 void PEG::validate () const
 {
-  if (_start == "")
+  if (_start.empty())
     throw std::string ("There are no rules defined.");
 
   std::vector <std::string> allRules;

--- a/src/Packrat.cpp
+++ b/src/Packrat.cpp
@@ -750,14 +750,14 @@ std::string Packrat::dump () const
   out << "Packrat Parse "
       << _tree->dump ();
 
-  if (_entities.size ())
+  if (!_entities.empty())
   {
     out << "  Entities\n";
     for (const auto& entity : _entities)
       out << "    " << entity.first << ':' << entity.second << '\n';
   }
 
-  if (_externals.size ())
+  if (!_externals.empty())
   {
     out << "  Externals\n";
     for (const auto& external : _externals)

--- a/src/RX.cpp
+++ b/src/RX.cpp
@@ -126,7 +126,7 @@ bool RX::match (
       ++offset;
   }
 
-  return matches.size () ? true : false;
+  return !matches.empty() ? true : false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,7 +153,7 @@ bool RX::match (
       ++offset;
   }
 
-  return start.size () ? true : false;
+  return !start.empty() ? true : false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -231,7 +231,7 @@ std::string Tree::dumpNode (
   std::string atts;
   for (auto& a : t->_attributes)
   {
-    if (atts != "")
+    if (!atts.empty())
       atts += ' ';
 
     atts += a.first + "='\033[33m" + a.second + "\033[0m'";

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -740,7 +740,7 @@ int execute (
   close (pin[0]);   // Close the read end of the input pipe.
   close (pout[1]);  // Close the write end of the output pipe.
 
-  if (input.size () == 0)
+  if (input.empty())
   {
     // Nothing to send to the child, close the pipe early.
     close (pin[1]);

--- a/test/negative.t.cpp
+++ b/test/negative.t.cpp
@@ -43,17 +43,17 @@ int main (int, char**)
   t.is (rules["thing"][0][0]._token,  "a",                                  "negative: thing: a");
   t.ok (rules["thing"][0][0]._quantifier == PEG::Token::Quantifier::one,    "negative: thing: a quantifier one");
   t.ok (rules["thing"][0][0]._lookahead == PEG::Token::Lookahead::none,     "negative: thing: a lookahead none");
-  t.ok (rules["thing"][0][0]._tags == std::set <std::string> {},            "negative: thing: a tags {}");
+  t.ok (rules["thing"][0][0]._tags.empty(),                                 "negative: thing: a tags {}");
 
   t.is (rules["thing"][0][1]._token,  "b",                                  "negative: thing: b");
   t.ok (rules["thing"][0][1]._quantifier == PEG::Token::Quantifier::one,    "negative: thing: b quantifier one");
   t.ok (rules["thing"][0][1]._lookahead == PEG::Token::Lookahead::negative, "negative: thing: b lookahead negative");
-  t.ok (rules["thing"][0][1]._tags == std::set <std::string> {},            "negative: thing: b tags {}");
+  t.ok (rules["thing"][0][1]._tags.empty(),                                 "negative: thing: b tags {}");
 
   t.is (rules["thing"][0][2]._token,  "c",                                  "negative: thing: c");
   t.ok (rules["thing"][0][2]._quantifier == PEG::Token::Quantifier::one,    "negative: thing: c quantifier one");
   t.ok (rules["thing"][0][2]._lookahead == PEG::Token::Lookahead::none,     "negative: thing: c lookahead none");
-  t.ok (rules["thing"][0][2]._tags == std::set <std::string> {},            "negative: thing: c tags {}");
+  t.ok (rules["thing"][0][2]._tags.empty(),                                 "negative: thing: c tags {}");
 
   t.is (rules["a"][0][0]._token,  "'a'",                                    "negative: a: char literal");
   t.ok (rules["a"][0][0]._quantifier == PEG::Token::Quantifier::one,        "negative: a: char literal quantifier one");

--- a/test/peg.t.cpp
+++ b/test/peg.t.cpp
@@ -98,33 +98,33 @@ int main (int, char**)
   t.is (rules["this"][0][0]._token,  "that",                                       "PEG: this: that");
   t.ok (rules["this"][0][0]._quantifier == PEG::Token::Quantifier::one_or_more,    "PEG: this: that quantifier one_or_more");
   t.ok (rules["this"][0][0]._lookahead == PEG::Token::Lookahead::none,             "PEG: this: that lookahead none");
-  t.ok (rules["this"][0][0]._tags == std::set <std::string> {},                    "PEG: this: that tags {}");
+  t.ok (rules["this"][0][0]._tags.empty(),                                         "PEG: this: that tags {}");
 
   t.is (rules["that"][0][0]._token,  "other",                                      "PEG: that: other");
   t.ok (rules["that"][0][0]._quantifier == PEG::Token::Quantifier::zero_or_one,    "PEG: that: other quantifier zero_or_one");
   t.ok (rules["that"][0][0]._lookahead == PEG::Token::Lookahead::none,             "PEG: that: other lookahead none");
-  t.ok (rules["that"][0][0]._tags == std::set <std::string> {},                    "PEG: that: other tags {}");
+  t.ok (rules["that"][0][0]._tags.empty(),                                         "PEG: that: other tags {}");
 
   t.is (rules["other"][0][0]._token, "a",                                          "PEG: other: a");
   t.ok (rules["other"][0][0]._quantifier == PEG::Token::Quantifier::zero_or_more,  "PEG: other: a quantifier zero_or_more");
   t.ok (rules["other"][0][0]._lookahead == PEG::Token::Lookahead::none,            "PEG: other: a lookahead none");
-  t.ok (rules["other"][0][0]._tags == std::set <std::string> {},                   "PEG: other: a tags {}");
+  t.ok (rules["other"][0][0]._tags.empty(),                                        "PEG: other: a tags {}");
   t.is (rules["other"][0][1]._token, "a",                                          "PEG: other: a");
   t.ok (rules["other"][0][1]._quantifier == PEG::Token::Quantifier::one,           "PEG: other: a quantifier one");
   t.ok (rules["other"][0][1]._lookahead == PEG::Token::Lookahead::none,            "PEG: other: a lookahead none");
-  t.ok (rules["other"][0][1]._tags == std::set <std::string> {},                   "PEG: other: a tags {}");
+  t.ok (rules["other"][0][1]._tags.empty(),                                        "PEG: other: a tags {}");
   t.is (rules["other"][0][2]._token, "a",                                          "PEG: other: a");
   t.ok (rules["other"][0][2]._quantifier == PEG::Token::Quantifier::one,           "PEG: other: a quantifier one");
   t.ok (rules["other"][0][2]._lookahead == PEG::Token::Lookahead::positive,        "PEG: other: a lookahead positive");
-  t.ok (rules["other"][0][2]._tags == std::set <std::string> {},                   "PEG: other: a tags {}");
+  t.ok (rules["other"][0][2]._tags.empty(),                                        "PEG: other: a tags {}");
   t.is (rules["other"][0][3]._token, "a",                                          "PEG: other: a");
   t.ok (rules["other"][0][3]._quantifier == PEG::Token::Quantifier::one,           "PEG: other: a quantifier one");
   t.ok (rules["other"][0][3]._lookahead == PEG::Token::Lookahead::none,            "PEG: other: a lookahead none");
-  t.ok (rules["other"][0][3]._tags == std::set <std::string> {},                   "PEG: other: a tags {}");
+  t.ok (rules["other"][0][3]._tags.empty(),                                        "PEG: other: a tags {}");
   t.is (rules["other"][0][4]._token, "a",                                          "PEG: other: a");
   t.ok (rules["other"][0][4]._quantifier == PEG::Token::Quantifier::one,           "PEG: other: a quantifier one");
   t.ok (rules["other"][0][4]._lookahead == PEG::Token::Lookahead::negative,        "PEG: other: a lookahead negative");
-  t.ok (rules["other"][0][4]._tags == std::set <std::string> {},                   "PEG: other: a tags {}");
+  t.ok (rules["other"][0][4]._tags.empty(),                                        "PEG: other: a tags {}");
 
   t.is (rules["a"][0][0]._token,     "'a'",                                        "PEG: a: 'a'");
   t.ok (rules["a"][0][0]._quantifier == PEG::Token::Quantifier::one,               "PEG: a: 'a' quantifier one");

--- a/test/plus.t.cpp
+++ b/test/plus.t.cpp
@@ -43,7 +43,7 @@ int main (int, char**)
   t.is (rules["thing"][0][0]._token,  "item",                                    "question: thing: item");
   t.ok (rules["thing"][0][0]._quantifier == PEG::Token::Quantifier::one_or_more, "question: thing: item quantifier one_or_more");
   t.ok (rules["thing"][0][0]._lookahead == PEG::Token::Lookahead::none,          "question: thing: item lookahead none");
-  t.ok (rules["thing"][0][0]._tags == std::set <std::string> {},                 "question: thing: item tags {}");
+  t.ok (rules["thing"][0][0]._tags.empty(),                                      "question: thing: item tags {}");
 
   t.is (rules["item"][0][0]._token,  "'a'",                                      "question: item: 'a'");
   t.ok (rules["item"][0][0]._quantifier == PEG::Token::Quantifier::one,          "question: item: 'a' quantifier one");

--- a/test/positive.t.cpp
+++ b/test/positive.t.cpp
@@ -43,17 +43,17 @@ int main (int, char**)
   t.is (rules["thing"][0][0]._token,  "a",                                  "positive: thing: a");
   t.ok (rules["thing"][0][0]._quantifier == PEG::Token::Quantifier::one,    "positive: thing: a quantifier one");
   t.ok (rules["thing"][0][0]._lookahead == PEG::Token::Lookahead::none,     "positive: thing: a lookahead none");
-  t.ok (rules["thing"][0][0]._tags == std::set <std::string> {},            "positive: thing: a tags {}");
+  t.ok (rules["thing"][0][0]._tags.empty(),                                 "positive: thing: a tags {}");
 
   t.is (rules["thing"][0][1]._token,  "b",                                  "positive: thing: b");
   t.ok (rules["thing"][0][1]._quantifier == PEG::Token::Quantifier::one,    "positive: thing: b quantifier one");
   t.ok (rules["thing"][0][1]._lookahead == PEG::Token::Lookahead::positive, "positive: thing: b lookahead positive");
-  t.ok (rules["thing"][0][1]._tags == std::set <std::string> {},            "positive: thing: b tags {}");
+  t.ok (rules["thing"][0][1]._tags.empty(),                                 "positive: thing: b tags {}");
 
   t.is (rules["thing"][0][2]._token,  "b",                                  "positive: thing: c");
   t.ok (rules["thing"][0][2]._quantifier == PEG::Token::Quantifier::one,    "positive: thing: c quantifier one");
   t.ok (rules["thing"][0][2]._lookahead == PEG::Token::Lookahead::none,     "positive: thing: c lookahead none");
-  t.ok (rules["thing"][0][2]._tags == std::set <std::string> {},            "positive: thing: c tags {}");
+  t.ok (rules["thing"][0][2]._tags.empty(),                                 "positive: thing: c tags {}");
 
   t.is (rules["a"][0][0]._token,  "'a'",                                    "positive: a: char literal");
   t.ok (rules["a"][0][0]._quantifier == PEG::Token::Quantifier::one,        "positive: a: char literal quantifier one");

--- a/test/question.t.cpp
+++ b/test/question.t.cpp
@@ -43,7 +43,7 @@ int main (int, char**)
   t.is (rules["thing"][0][0]._token,  "item",                                    "question: thing: item");
   t.ok (rules["thing"][0][0]._quantifier == PEG::Token::Quantifier::zero_or_one, "question: thing: item quantifier zero_or_one");
   t.ok (rules["thing"][0][0]._lookahead == PEG::Token::Lookahead::none,          "question: thing: item lookahead none");
-  t.ok (rules["thing"][0][0]._tags == std::set <std::string> {},                 "question: thing: item tags {}");
+  t.ok (rules["thing"][0][0]._tags.empty(),                                      "question: thing: item tags {}");
 
   t.is (rules["item"][0][0]._token,  "'a'",                                      "question: item: 'a'");
   t.ok (rules["item"][0][0]._quantifier == PEG::Token::Quantifier::one,          "question: item: 'a' quantifier one");

--- a/test/star.t.cpp
+++ b/test/star.t.cpp
@@ -43,7 +43,7 @@ int main (int, char**)
   t.is (rules["thing"][0][0]._token,  "item",                                     "question: thing: item");
   t.ok (rules["thing"][0][0]._quantifier == PEG::Token::Quantifier::zero_or_more, "question: thing: item quantifier zero_or_more");
   t.ok (rules["thing"][0][0]._lookahead == PEG::Token::Lookahead::none,           "question: thing: item lookahead none");
-  t.ok (rules["thing"][0][0]._tags == std::set <std::string> {},                  "question: thing: item tags {}");
+  t.ok (rules["thing"][0][0]._tags.empty(),                                       "question: thing: item tags {}");
 
   t.is (rules["item"][0][0]._token,  "'a'",                                       "question: item: 'a'");
   t.ok (rules["item"][0][0]._quantifier == PEG::Token::Quantifier::one,           "question: item: 'a' quantifier one");


### PR DESCRIPTION
Found with readability-container-size-empty

Signed-off-by: Rosen Penev <rosenp@gmail.com>