### PR TITLE
manual conversions to empty()

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -144,7 +144,7 @@ void Configuration::load (
       config.readable ())
   {
     std::string contents;
-    if (File::read (file, contents) && contents.length ())
+    if (File::read (file, contents) && !contents.empty ())
       parse (contents, nest, search_paths, file);
   }
 }
@@ -169,7 +169,7 @@ void Configuration::parse (
   const std::string& file_path /* = {} */)
 {
   // Shortcut case for default constructor.
-  if (input.length () == 0)
+  if (input.empty ())
     return;
 
   // Parse each line.
@@ -182,7 +182,7 @@ void Configuration::parse (
 
     // Skip empty lines.
     line = trim (line);
-    if (line.length () > 0)
+    if (!line.empty ())
     {
       auto equal = line.find ('=');
       if (equal != std::string::npos)

--- a/src/FS.cpp
+++ b/src/FS.cpp
@@ -114,7 +114,7 @@ Path::operator std::string () const
 ////////////////////////////////////////////////////////////////////////////////
 std::string Path::name () const
 {
-  if (_data.length ())
+  if (!_data.empty ())
   {
     auto slash = _data.rfind ('/');
     if (slash != std::string::npos)
@@ -127,7 +127,7 @@ std::string Path::name () const
 ////////////////////////////////////////////////////////////////////////////////
 std::string Path::parent () const
 {
-  if (_data.length ())
+  if (!_data.empty ())
   {
     auto slash = _data.rfind ('/');
     if (slash != std::string::npos)
@@ -141,7 +141,7 @@ std::string Path::parent () const
 ////////////////////////////////////////////////////////////////////////////////
 std::string Path::extension () const
 {
-  if (_data.length ())
+  if (!_data.empty ())
   {
     auto dot = _data.rfind ('.');
     if (dot != std::string::npos)
@@ -190,7 +190,7 @@ bool Path::is_directory () const
 ////////////////////////////////////////////////////////////////////////////////
 bool Path::is_absolute () const
 {
-  if (_data.length () && _data[0] == '/')
+  if (!_data.empty () && _data[0] == '/')
     return true;
 
   return false;

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -237,20 +237,20 @@ std::string Tree::dumpNode (
     atts += a.first + "='\033[33m" + a.second + "\033[0m'";
   }
 
-  if (atts.length ())
+  if (!atts.empty ())
     out << ' ' << atts;
 
   // Dump tags.
   std::string tags;
   for (auto& tag : t->_tags)
   {
-    if (tags.length ())
+    if (!tags.empty ())
       tags += ' ';
 
     tags += "\033[32m" + tag + "\033[0m";
   }
 
-  if (tags.length ())
+  if (!tags.empty ())
     out << ' ' << tags;
   out << '\n';
 

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -68,7 +68,7 @@ std::vector <std::string> split (const std::string& input, const char delimiter)
     start = i + 1;
   }
 
-  if (input.length ())
+  if (!input.empty ())
     results.push_back (input.substr (start));
 
   return results;


### PR DESCRIPTION
clang-tidy doesn't convert these for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>