### PR TITLE
clang-tidy: avoid double const

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -3298,7 +3298,7 @@ void Datetime::toYMD (int& y, int& m, int& d) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string Datetime::toString (const std::string& format) const
+std::string Datetime::toString (const std::string& format) const
 {
   std::stringstream formatted;
   for (unsigned int i = 0; i < format.length (); ++i)

--- a/src/Datetime.h
+++ b/src/Datetime.h
@@ -53,7 +53,7 @@ public:
   std::string toISOLocalExtended () const;
   double toJulian () const;
   void toYMD (int&, int&, int&) const;
-  const std::string toString (const std::string& format = "Y-M-D") const;
+  std::string toString (const std::string& format = "Y-M-D") const;
 
   Datetime startOfDay () const;
   Datetime startOfWeek () const;

--- a/src/Duration.cpp
+++ b/src/Duration.cpp
@@ -396,7 +396,7 @@ void Duration::clear ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string Duration::format () const
+std::string Duration::format () const
 {
   if (_period)
   {
@@ -425,7 +425,7 @@ const std::string Duration::format () const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string Duration::formatHours () const
+std::string Duration::formatHours () const
 {
   if (_period)
   {
@@ -450,7 +450,7 @@ const std::string Duration::formatHours () const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string Duration::formatISO () const
+std::string Duration::formatISO () const
 {
   if (_period)
   {
@@ -491,7 +491,7 @@ const std::string Duration::formatISO () const
 // >= 1min    {n}min
 //            {n}s
 //
-const std::string Duration::formatVague (bool padding) const
+std::string Duration::formatVague (bool padding) const
 {
   float days = (float) _period / 86400.0;
 

--- a/src/Duration.h
+++ b/src/Duration.h
@@ -50,10 +50,10 @@ public:
   bool parse_designated (Pig&);
   bool parse_weeks (Pig&);
   bool parse_units (Pig&);
-  const std::string format () const;
-  const std::string formatHours () const;
-  const std::string formatISO () const;
-  const std::string formatVague (bool padding = false) const;
+  std::string format () const;
+  std::string formatHours () const;
+  std::string formatISO () const;
+  std::string formatVague (bool padding = false) const;
 
   int days () const;
   int hours () const;

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -91,7 +91,7 @@ std::vector <std::tuple <std::string, Lexer::Type>> Lexer::tokenize (const std::
 
 ////////////////////////////////////////////////////////////////////////////////
 // No L10N - these are for internal purposes.
-const std::string Lexer::typeName (const Lexer::Type& type)
+std::string Lexer::typeName (const Lexer::Type& type)
 {
   switch (type)
   {

--- a/src/Lexer.h
+++ b/src/Lexer.h
@@ -54,7 +54,7 @@ public:
 
   // Static helpers.
   static std::vector <std::tuple <std::string, Lexer::Type>> tokenize (const std::string&);
-  static const std::string typeName          (const Lexer::Type&);
+  static std::string typeName          (const Lexer::Type&);
   static bool isSingleCharOperator           (int);
   static bool isDoubleCharOperator           (int, int, int);
   static bool isTripleCharOperator           (int, int, int, int);

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -41,20 +41,20 @@
 #include <cmath>
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string format (std::string& value)
+std::string format (std::string& value)
 {
   return value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string format (const char* value)
+std::string format (const char* value)
 {
   std::string s (value);
   return s;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string formatHex (int value)
+std::string formatHex (int value)
 {
   std::stringstream s;
   s.setf (std::ios::hex, std::ios::basefield);
@@ -63,7 +63,7 @@ const std::string formatHex (int value)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string format (float value, int width, int precision)
+std::string format (float value, int width, int precision)
 {
   std::stringstream s;
   s.width (width);
@@ -82,7 +82,7 @@ const std::string format (float value, int width, int precision)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string format (double value, int width, int precision)
+std::string format (double value, int width, int precision)
 {
   std::stringstream s;
   s.width (width);
@@ -101,7 +101,7 @@ const std::string format (double value, int width, int precision)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string format (double value)
+std::string format (double value)
 {
   std::stringstream s;
   s << std::fixed << value;

--- a/src/format.h
+++ b/src/format.h
@@ -32,12 +32,12 @@
 #include <string>
 #include <vector>
 
-const std::string format (std::string&);
-const std::string format (const char*);
-const std::string formatHex (int);
-const std::string format (float, int, int);
-const std::string format (double, int, int);
-const std::string format (double);
+std::string format (std::string&);
+std::string format (const char*);
+std::string formatHex (int);
+std::string format (float, int, int);
+std::string format (double, int, int);
+std::string format (double);
 
 void replace_positional (std::string&, const std::string&, const std::string&);
 

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -268,7 +268,7 @@ unsigned int utf8_text_width (const std::string& str)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-const std::string utf8_substr (
+std::string utf8_substr (
   const std::string& input,
   unsigned int start,
   unsigned int length /* = 0 */)

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -37,7 +37,7 @@ unsigned int utf8_length (const std::string&);
 unsigned int utf8_text_length (const std::string&);
 unsigned int utf8_width (const std::string& str);
 unsigned int utf8_text_width (const std::string&);
-const std::string utf8_substr (const std::string&, unsigned int, unsigned int length = 0);
+std::string utf8_substr (const std::string&, unsigned int, unsigned int length = 0);
 
 int mk_wcwidth (wchar_t);
 


### PR DESCRIPTION
Found with readability-const-return-type

Signed-off-by: Rosen Penev <rosenp@gmail.com>