### PR TITLE
clang-tidy: remove pointless string init

### DIFF
--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -37,7 +37,7 @@
 static const std::string uuid_pattern = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 static const unsigned int uuid_min_length = 8;
 
-std::string Lexer::dateFormat = "";
+std::string Lexer::dateFormat;
 
 ////////////////////////////////////////////////////////////////////////////////
 Lexer::Lexer (const std::string& text)

--- a/src/PEG.cpp
+++ b/src/PEG.cpp
@@ -83,7 +83,7 @@ void PEG::loadFromFile (File& file)
 void PEG::loadFromString (const std::string& input)
 {
   // This is a state machine.  Read each line.
-  std::string rule_name = "";
+  std::string rule_name;
   for (auto& line : loadImports (split (input, '\n')))
   {
     line = trim (removeComment (line));

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -667,7 +667,7 @@ bool confirm (const std::string& question)
     std::cout << question
               << " (yes/no) ";
 
-    std::string answer {""};
+    std::string answer;
     std::getline (std::cin, answer);
     answer = std::cin.eof () ? "no" : lowerCase (trim (answer));
 

--- a/test/shared.t.cpp
+++ b/test/shared.t.cpp
@@ -150,7 +150,7 @@ int main (int, char**)
 */
 
   // std::vector <std::string> split (const std::string& input, const char delimiter)
-  std::string unsplit = "";
+  std::string unsplit;
   std::vector <std::string> items = split (unsplit, '-');
   t.is (items.size (), (size_t) 0, "split '' '-' -> 0 items");
 


### PR DESCRIPTION
Found with readability-redundant-string-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>