### PR TITLE
clang-tidy: fix inconsistent declarations

### DIFF
--- a/src/RX.h
+++ b/src/RX.h
@@ -35,7 +35,7 @@ class RX
 {
 public:
   RX ();
-  RX (const std::string&, bool caseSensitive = true);
+  RX (const std::string&, bool case_sensitive = true);
   RX (const RX&);
   ~RX ();
   RX& operator= (const RX&);


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>