### PR TITLE
clang-tidy: remove redundant init

### DIFF
--- a/src/RX.cpp
+++ b/src/RX.cpp
@@ -38,8 +38,7 @@ RX::RX ()
 RX::RX (
   const std::string& pattern,
   bool case_sensitive /* = true */)
-: _compiled (false)
-, _pattern (pattern)
+: _pattern (pattern)
 , _case_sensitive (case_sensitive)
 {
   compile ();


### PR DESCRIPTION
Found with modernize-use-default-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>