### PR TITLE
Parse env variables for configuration options

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -189,6 +189,7 @@ void Configuration::parse (
       {
         std::string key   = trim (line.substr (0, equal));
         std::string value = trim (line.substr (equal+1, line.length () - equal));
+        value = Path::expand(value);
 
         (*this)[key] = json::decode (value);
       }


### PR DESCRIPTION
Configuration options that contain environment variables are now parsed.
This allows for example setting the path of the TLS keys for
synchronization with the taskd server different on each machine.