### PR TITLE
Datetime: parse_time_off should respect standaloneTimeEnabled

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -189,9 +189,9 @@ bool Datetime::parse (
                                             parse_time_utc_ext  (pig)  ||
                                             parse_time_utc      (pig)  ||
                                             parse_time_off_ext  (pig)  ||
-                                            parse_time_off      (pig)  ||
                                             parse_time_ext      (pig)  ||
-        (Datetime::standaloneTimeEnabled && parse_time          (pig)) // Time last, as it is the most permissive.
+        (Datetime::standaloneTimeEnabled && parse_time          (pig)) || // Time last, as it is the most permissive.
+        (Datetime::standaloneTimeEnabled && parse_time_off      (pig))
        )
       )
      )
@@ -1041,7 +1041,7 @@ bool Datetime::parse_time_utc (Pig& pig)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// <time> <off>
+// <time><off>
 bool Datetime::parse_time_off (Pig& pig)
 {
   auto checkpoint = pig.cursor ();


### PR DESCRIPTION
The parse_time method is enforced only if standaloneTimeEnabled is set
to true, because it's rather liberal - in particular, many four digit
numbers can be interpreted as 4 digit time (i.e 1020 standing for
10:20am).

It only follows that parse_time_off, which identifies offsetted time
tokens of the form hh[mm]±hh[mm] (which can match a token representing a
range, i.e. '1020-1024') should also respect the same flag.

Related to https://github.com/GothenburgBitFactory/taskwarrior/issues/2639.