### PR TITLE
Fix the computation for the soww named date

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -2002,7 +2002,7 @@ bool Datetime::initializeSoww (Pig& pig)
       time_t now = time (nullptr);
       struct tm* t = localtime (&now);
 
-      t->tm_mday += 8 - t->tm_wday;
+      t->tm_mday += 1 - t->tm_wday;
       t->tm_hour = t->tm_min = t->tm_sec = 0;
       t->tm_isdst = -1;
       _date = mktime (t);

--- a/test/dates.t.cpp
+++ b/test/dates.t.cpp
@@ -265,7 +265,7 @@ int main (int, char**)
   t.ok (sopww < soww,               "sopww < soww");
   t.ok (sopy < soy,                 "sopy < soy");
   t.ok (sow < sonw,                 "sow < sonw");
-  t.ok (soww == sonww,              "soww == sonww");
+  t.ok (soww < sonww,               "soww < sonww");
   t.ok (soy > sopy,                 "soy > sopy");
   t.ok (today < tomorrow,           "today < tomorrow");
   t.ok (yesterday < today,          "yesterday < today");


### PR DESCRIPTION
This partially resolves #49, by making sure that `soww` refers to the current work week. Also adjusts the tests accordingly.