### PR TITLE
JSON: Fix build with GCC 13

### DIFF
--- a/src/JSON.h
+++ b/src/JSON.h
@@ -27,6 +27,7 @@
 #ifndef INCLUDED_JSON
 #define INCLUDED_JSON
 
+#include <cstdint>
 #include <map>
 #include <vector>
 #include <string>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895122