### PR TITLE
Fix calculation of 'end of previous work week'

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -2056,7 +2056,7 @@ bool Datetime::initializeEopww (Pig& pig)
       time_t now = time (nullptr);
       struct tm* t = localtime (&now);
 
-      t->tm_mday -= (t->tm_wday + 1) % 7;
+      t->tm_mday -= t->tm_wday + 1;
       t->tm_hour = t->tm_min = 0;
       t->tm_sec = -1;
       t->tm_isdst = -1;

--- a/test/dates.t.cpp
+++ b/test/dates.t.cpp
@@ -52,7 +52,7 @@ void testInit (UnitTest& t, const std::string& value, Datetime& var)
 ////////////////////////////////////////////////////////////////////////////////
 int main (int, char**)
 {
-  UnitTest t (164);
+  UnitTest t (201);
 
   Datetime sunday;    testInit (t, "sunday",    sunday);
   Datetime monday;    testInit (t, "monday",    monday);


### PR DESCRIPTION
The calculation of the _end of previous work week_ (eopww) fails if the current day is a Saturday.
The algorithm ([Datetime.cpp:2059](https://github.com/GothenburgBitFactory/libshared/blob/ee050a2cc68c46e8748113246b26feb0ad9f34c5/src/Datetime.cpp#L2059-L2063)) subtracts the current weekday (with Sunday = 0) plus one modulo 7 from the current day of month.

When the current day is a Saturday, this results in a subtraction of 0, i.e. the current day remains unchanged, while it should be the previous Saturday.

Dropping the modulo fixes the issue.