### PR TITLE
Add integration tests for Timewarrior and Taskwarrior

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,3 +45,22 @@ jobs:
       shell: bash
       # Execute tests
       run: make test
+
+  integration-test:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - name: "Timewarrior [stable]"
+            container: "timew-libshared-stable"
+          - name: "Timewarrior [develop]"
+            container: "timew-libshared-develop"
+          - name: "Taskwarrior [stable]"
+            container: "task-libshared-stable"
+          - name: "Taskwarrior [develop]"
+            container: "task-libshared-develop"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Test on ${{ matrix.name }}"
+        run: docker-compose up ${{ matrix.container }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+###############################################################################
+#
+# Copyright 2023, Gothenburg Bit Factory
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# https://www.opensource.org/licenses/mit-license.php
+#
+###############################################################################
+
+version: '3'
+services:
+  timew-libshared-stable:
+    build:
+      context: .
+      dockerfile: test/docker/timew.dockerfile
+      args:
+        BRANCH: "stable"
+    network_mode: "host"
+    security_opt:
+      - label=type:container_runtime_t
+    tty: true
+
+  timew-libshared-develop:
+    build:
+      context: .
+      dockerfile: test/docker/timew.dockerfile
+      args:
+        BRANCH: "develop"
+    network_mode: "host"
+    security_opt:
+      - label=type:container_runtime_t
+    tty: true
+
+  task-libshared-stable:
+    build:
+      context: .
+      dockerfile: test/docker/task.dockerfile
+      args:
+        BRANCH: "stable"
+    network_mode: "host"
+    security_opt:
+      - label=type:container_runtime_t
+    tty: true
+
+  task-libshared-develop:
+    build:
+      context: .
+      dockerfile: test/docker/task.dockerfile
+      args:
+        BRANCH: "develop"
+    network_mode: "host"
+    security_opt:
+      - label=type:container_runtime_t
+    tty: true

--- a/test/docker/task.dockerfile
+++ b/test/docker/task.dockerfile
@@ -1,0 +1,72 @@
+###############################################################################
+#
+# Copyright 2023, Gothenburg Bit Factory
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# https://www.opensource.org/licenses/mit-license.php
+#
+###############################################################################
+
+ARG BRANCH
+
+FROM ubuntu:22.04 AS base
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+            build-essential \
+            cmake \
+            curl \
+            faketime \
+            git \
+            libgnutls28-dev \
+            locales \
+            python3 \
+            uuid-dev
+
+# Setup language environment
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
+    sh rustup.sh -y --profile minimal --default-toolchain stable --component rust-docs
+
+# Checkout Taskwarrior
+WORKDIR /root
+RUN git clone https://github.com/GothenburgBitFactory/taskwarrior.git code
+WORKDIR code
+RUN git checkout ${BRANCH}
+
+FROM base AS builder
+
+# Add libshared
+ADD . src/libshared
+
+# Build Taskwarrior
+RUN cmake -DCMAKE_BUILD_TYPE=release . && \
+    make -j8
+
+WORKDIR test
+RUN make
+
+CMD ["bash", "-c", "./run_all -v ; cat all.log | grep 'not ok' ; ./problems ; FAILED=$? ; python3 --version ; cmake --version ; gcc --version ; exit $FAILED"]

--- a/test/docker/timew.dockerfile
+++ b/test/docker/timew.dockerfile
@@ -1,0 +1,68 @@
+###############################################################################
+#
+# Copyright 2023, Gothenburg Bit Factory
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# https://www.opensource.org/licenses/mit-license.php
+#
+###############################################################################
+
+ARG BRANCH
+
+FROM ubuntu:22.04 AS base
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN ( apt-get update && yes | unminimize ) && \
+    apt-get install -y \
+            asciidoctor \
+            cmake \
+            g++ \
+            git \
+            man \
+            man-db \
+            python3 \
+            python3-dateutil \
+            tzdata
+
+# Setup language environment
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Checkout Timewarrior
+WORKDIR /root
+RUN git clone https://github.com/GothenburgBitFactory/timewarrior.git code
+WORKDIR code
+RUN git checkout ${BRANCH}
+
+FROM base AS builder
+
+# Add libshared
+ADD . src/libshared
+
+# Build Timewarrior
+RUN cmake -DCMAKE_BUILD_TYPE=release . && \
+    make -j8
+
+WORKDIR test
+RUN make
+
+CMD ["bash", "-c", "./run_all -v ; cat all.log | grep 'not ok' ; ./problems ; FAILED=$? ; python3 --version ; cmake --version ; gcc --version ; exit $FAILED"]


### PR DESCRIPTION
Build both, Taskwarrior and Timewarrior, at 'stable' and 'develop' with the current version of libshared.