### PR TITLE
Make week number parsing ISO8601 compliant for weekstart=1

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -3512,14 +3512,26 @@ int Datetime::dayOfWeek (const std::string& input)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Using Zeller's Congruence.
+// Using variant of Zeller's Congruence snarfed from RFC3339 appendix B
 // Static
 int Datetime::dayOfWeek (int year, int month, int day)
 {
-  int adj = (14 - month) / 12;
-  int m = month + 12 * adj - 2;
-  int y = year - adj;
-  return (day + (13 * m - 1) / 5 + y + y / 4 - y / 100 + y / 400) % 7;
+  int cent;
+
+  /* adjust months so February is the last one */
+  month -= 2;
+  if (month < 1)
+  {
+    month += 12;
+    --year;
+  }
+
+  /* split by century */
+  cent = year / 100;
+  year %= 100;
+
+  return ((26 * month - 2) / 10
+          + day + year + year / 4 + cent / 4 + 5 * cent) % 7;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/datetime.t.cpp
+++ b/test/datetime.t.cpp
@@ -179,312 +179,327 @@ int main (int, char**)
   std::cout << "# ld " << ld << '\n';
   std::cout << "# ud " << ud << '\n';
 
-  // Aggregated.
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "12:34:56  ",                 8,    0,  0,  0, 0,   0,  0,   hms,     0, false, local+hms+ld );
+  int wks;
 
-  // time-ext
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "12:34:56Z",                  9,    0,  0,  0, 0,   0,  0,   hms,     0,  true, utc+hms+ud   );
-  testParse (t, "12:34Z",                     6,    0,  0,  0, 0,   0,  0,    hm,     0,  true, utc+hm+ud    );
-  testParse (t, "12:34:56+01:00",            14,    0,  0,  0, 0,   0,  0,   hms,  3600, false, utc+hms-z+ud );
-  testParse (t, "12:34:56+01",               11,    0,  0,  0, 0,   0,  0,   hms,  3600, false, utc+hms-z+ud );
-  testParse (t, "12:34+01:00",               11,    0,  0,  0, 0,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
-  testParse (t, "12:34+01",                   8,    0,  0,  0, 0,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
-  testParse (t, "12:34:56",                   8,    0,  0,  0, 0,   0,  0,   hms,     0, false, local+hms+ld );
-  testParse (t, "12:34",                      5,    0,  0,  0, 0,   0,  0,    hm,     0, false, local+hm+ld  );
+  for (wks = 0; wks <= 1; wks++)
+  {
+    // Run the test parses against both weekstarts
+    Datetime::weekstart = wks;
 
-  // datetime-ext
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "2013-12-06",                10, year, mo,  0, 0,   0,  6,     0,     0, false, local6    );
-  testParse (t, "2013-340",                   8, year,  0,  0, 0, 340,  0,     0,     0, false, local6    );
-  testParse (t, "2013-W49-5",                10, year,  0, 49, 5,   0,  0,     0,     0, false, local6    );
-  testParse (t, "2013-W49",                   8, year,  0, 49, 0,   0,  0,     0,     0, false, local1    );
-  testParse (t, "2013-12",                    7, year, mo,  0, 0,   0,  1,     0,     0, false, local1    );
+    // 2013-W49 tests without weekday differ by one day depending on weekstart.
+    // None of these variables are used following this loop.
+    f_local1  += wks * 86400;
+    f_utc1    += wks * 86400;
+    local1    += wks * 86400;
+    utc1      += wks * 86400;
 
-  testParse (t, "2013-12-06T12:34:56",       19, year, mo,  0, 0,   0,  6,   hms,     0, false, local6+hms);
-  testParse (t, "2013-12-06T12:34",          16, year, mo,  0, 0,   0,  6,    hm,     0, false, local6+hm );
-  testParse (t, "2013-340T12:34:56",         17, year,  0,  0, 0, 340,  0,   hms,     0, false, local6+hms);
-  testParse (t, "2013-340T12:34",            14, year,  0,  0, 0, 340,  0,    hm,     0, false, local6+hm );
-  testParse (t, "2013-W49-5T12:34:56",       19, year,  0, 49, 5,   0,  0,   hms,     0, false, local6+hms);
-  testParse (t, "2013-W49-5T12:34",          16, year,  0, 49, 5,   0,  0,    hm,     0, false, local6+hm );
-  testParse (t, "2013-W49T12:34:56",         17, year,  0, 49, 0,   0,  0,   hms,     0, false, local1+hms);
-  testParse (t, "2013-W49T12:34",            14, year,  0, 49, 0,   0,  0,    hm,     0, false, local1+hm );
+    // Aggregated.
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "12:34:56  ",                 8,    0,  0,  0, wks,   0,  0,   hms,     0, false, local+hms+ld );
 
-  testParse (t, "2013-12-06T12:34:56Z",      20, year, mo,  0, 0,   0,  6,   hms,     0,  true, utc6+hms  );
-  testParse (t, "2013-12-06T12:34Z",         17, year, mo,  0, 0,   0,  6,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013-340T12:34:56Z",        18, year,  0,  0, 0, 340,  0,   hms,     0,  true, utc6+hms  );
-  testParse (t, "2013-340T12:34Z",           15, year,  0,  0, 0, 340,  0,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013-W49-5T12:34:56Z",      20, year,  0, 49, 5,   0,  0,   hms,     0,  true, utc6+hms  );
-  testParse (t, "2013-W49-5T12:34Z",         17, year,  0, 49, 5,   0,  0,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013-W49T12:34:56Z",        18, year,  0, 49, 0,   0,  0,   hms,     0,  true, utc1+hms  );
-  testParse (t, "2013-W49T12:34Z",           15, year,  0, 49, 0,   0,  0,    hm,     0,  true, utc1+hm   );
+    // time-ext
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "12:34:56Z",                  9,    0,  0,  0, wks,   0,  0,   hms,     0,  true, utc+hms+ud   );
+    testParse (t, "12:34Z",                     6,    0,  0,  0, wks,   0,  0,    hm,     0,  true, utc+hm+ud    );
+    testParse (t, "12:34:56+01:00",            14,    0,  0,  0, wks,   0,  0,   hms,  3600, false, utc+hms-z+ud );
+    testParse (t, "12:34:56+01",               11,    0,  0,  0, wks,   0,  0,   hms,  3600, false, utc+hms-z+ud );
+    testParse (t, "12:34+01:00",               11,    0,  0,  0, wks,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
+    testParse (t, "12:34+01",                   8,    0,  0,  0, wks,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
+    testParse (t, "12:34:56",                   8,    0,  0,  0, wks,   0,  0,   hms,     0, false, local+hms+ld );
+    testParse (t, "12:34",                      5,    0,  0,  0, wks,   0,  0,    hm,     0, false, local+hm+ld  );
 
-  testParse (t, "2013-12-06T12:34:56+01:00", 25, year, mo,  0, 0,   0,  6,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-12-06T12:34:56+01",    22, year, mo,  0, 0,   0,  6,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-12-06T12:34:56-01:00", 25, year, mo,  0, 0,   0,  6,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-12-06T12:34:56-01",    22, year, mo,  0, 0,   0,  6,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-12-06T12:34+01:00",    22, year, mo,  0, 0,   0,  6,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-12-06T12:34+01",       19, year, mo,  0, 0,   0,  6,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-12-06T12:34-01:00",    22, year, mo,  0, 0,   0,  6,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-12-06T12:34-01",       19, year, mo,  0, 0,   0,  6,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-340T12:34:56+01:00",   23, year,  0,  0, 0, 340,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-340T12:34:56+01",      20, year,  0,  0, 0, 340,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-340T12:34:56-01:00",   23, year,  0,  0, 0, 340,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-340T12:34:56-01",      20, year,  0,  0, 0, 340,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-340T12:34+01:00",      20, year,  0,  0, 0, 340,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-340T12:34+01",         17, year,  0,  0, 0, 340,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-340T12:34-01:00",      20, year,  0,  0, 0, 340,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-340T12:34-01",         17, year,  0,  0, 0, 340,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-W49-5T12:34:56+01:00", 25, year,  0, 49, 5,   0,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-W49-5T12:34:56+01",    22, year,  0, 49, 5,   0,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013-W49-5T12:34:56-01:00", 25, year,  0, 49, 5,   0,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-W49-5T12:34:56-01",    22, year,  0, 49, 5,   0,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013-W49-5T12:34+01:00",    22, year,  0, 49, 5,   0,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-W49-5T12:34+01",       19, year,  0, 49, 5,   0,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013-W49-5T12:34-01:00",    22, year,  0, 49, 5,   0,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-W49-5T12:34-01",       19, year,  0, 49, 5,   0,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013-W49T12:34:56+01:00",   23, year,  0, 49, 0,   0,  0,   hms,  3600, false, utc1+hms-z);
-  testParse (t, "2013-W49T12:34:56+01",      20, year,  0, 49, 0,   0,  0,   hms,  3600, false, utc1+hms-z);
-  testParse (t, "2013-W49T12:34:56-01:00",   23, year,  0, 49, 0,   0,  0,   hms, -3600, false, utc1+hms+z);
-  testParse (t, "2013-W49T12:34:56-01",      20, year,  0, 49, 0,   0,  0,   hms, -3600, false, utc1+hms+z);
-  testParse (t, "2013-W49T12:34+01:00",      20, year,  0, 49, 0,   0,  0,    hm,  3600, false, utc1+hm-z );
-  testParse (t, "2013-W49T12:34+01",         17, year,  0, 49, 0,   0,  0,    hm,  3600, false, utc1+hm-z );
-  testParse (t, "2013-W49T12:34-01:00",      20, year,  0, 49, 0,   0,  0,    hm, -3600, false, utc1+hm+z );
-  testParse (t, "2013-W49T12:34-01",         17, year,  0, 49, 0,   0,  0,    hm, -3600, false, utc1+hm+z );
+    // datetime-ext
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "2013-12-06",                10, year, mo,  0, wks,   0,  6,     0,     0, false, local6    );
+    testParse (t, "2013-340",                   8, year,  0,  0, wks, 340,  0,     0,     0, false, local6    );
+    testParse (t, "2013-W49-5",                10, year,  0, 49, 5,     0,  0,     0,     0, false, local6    );
+    testParse (t, "2013-W49",                   8, year,  0, 49, wks,   0,  0,     0,     0, false, local1    );
+    testParse (t, "2013-12",                    7, year, mo,  0, wks,   0,  1,     0,     0, false, local1 - 86400 * wks);
 
-  // datetime-ext in the future
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "9850-12-06",                10, f_yr, mo,  0, 0,   0,  6,     0,     0, false, f_local6    );
-  testParse (t, "9850-340",                   8, f_yr,  0,  0, 0, 340,  0,     0,     0, false, f_local6    );
-  testParse (t, "9850-W49-5",                10, f_yr,  0, 49, 5,   0,  0,     0,     0, false, f_local6    );
-  testParse (t, "9850-W49",                   8, f_yr,  0, 49, 0,   0,  0,     0,     0, false, f_local1    );
-  testParse (t, "9850-12",                    7, f_yr, mo,  0, 0,   0,  1,     0,     0, false, f_local1    );
+    testParse (t, "2013-12-06T12:34:56",       19, year, mo,  0, wks,   0,  6,   hms,     0, false, local6+hms);
+    testParse (t, "2013-12-06T12:34",          16, year, mo,  0, wks,   0,  6,    hm,     0, false, local6+hm );
+    testParse (t, "2013-340T12:34:56",         17, year,  0,  0, wks, 340,  0,   hms,     0, false, local6+hms);
+    testParse (t, "2013-340T12:34",            14, year,  0,  0, wks, 340,  0,    hm,     0, false, local6+hm );
+    testParse (t, "2013-W49-5T12:34:56",       19, year,  0, 49, 5,     0,  0,   hms,     0, false, local6+hms);
+    testParse (t, "2013-W49-5T12:34",          16, year,  0, 49, 5,     0,  0,    hm,     0, false, local6+hm );
+    testParse (t, "2013-W49T12:34:56",         17, year,  0, 49, wks,   0,  0,   hms,     0, false, local1+hms);
+    testParse (t, "2013-W49T12:34",            14, year,  0, 49, wks,   0,  0,    hm,     0, false, local1+hm );
 
-  testParse (t, "9850-12-06T12:34:56",       19, f_yr, mo,  0, 0,   0,  6,   hms,     0, false, f_local6+hms);
-  testParse (t, "9850-12-06T12:34",          16, f_yr, mo,  0, 0,   0,  6,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850-340T12:34:56",         17, f_yr,  0,  0, 0, 340,  0,   hms,     0, false, f_local6+hms);
-  testParse (t, "9850-340T12:34",            14, f_yr,  0,  0, 0, 340,  0,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850-W49-5T12:34:56",       19, f_yr,  0, 49, 5,   0,  0,   hms,     0, false, f_local6+hms);
-  testParse (t, "9850-W49-5T12:34",          16, f_yr,  0, 49, 5,   0,  0,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850-W49T12:34:56",         17, f_yr,  0, 49, 0,   0,  0,   hms,     0, false, f_local1+hms);
-  testParse (t, "9850-W49T12:34",            14, f_yr,  0, 49, 0,   0,  0,    hm,     0, false, f_local1+hm );
+    testParse (t, "2013-12-06T12:34:56Z",      20, year, mo,  0, wks,   0,  6,   hms,     0,  true, utc6+hms  );
+    testParse (t, "2013-12-06T12:34Z",         17, year, mo,  0, wks,   0,  6,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013-340T12:34:56Z",        18, year,  0,  0, wks, 340,  0,   hms,     0,  true, utc6+hms  );
+    testParse (t, "2013-340T12:34Z",           15, year,  0,  0, wks, 340,  0,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013-W49-5T12:34:56Z",      20, year,  0, 49, 5,     0,  0,   hms,     0,  true, utc6+hms  );
+    testParse (t, "2013-W49-5T12:34Z",         17, year,  0, 49, 5,     0,  0,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013-W49T12:34:56Z",        18, year,  0, 49, wks,   0,  0,   hms,     0,  true, utc1+hms  );
+    testParse (t, "2013-W49T12:34Z",           15, year,  0, 49, wks,   0,  0,    hm,     0,  true, utc1+hm   );
 
-  testParse (t, "9850-12-06T12:34:56Z",      20, f_yr, mo,  0, 0,   0,  6,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "9850-12-06T12:34Z",         17, f_yr, mo,  0, 0,   0,  6,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850-340T12:34:56Z",        18, f_yr,  0,  0, 0, 340,  0,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "9850-340T12:34Z",           15, f_yr,  0,  0, 0, 340,  0,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850-W49-5T12:34:56Z",      20, f_yr,  0, 49, 5,   0,  0,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "9850-W49-5T12:34Z",         17, f_yr,  0, 49, 5,   0,  0,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850-W49T12:34:56Z",        18, f_yr,  0, 49, 0,   0,  0,   hms,     0,  true, f_utc1+hms  );
-  testParse (t, "9850-W49T12:34Z",           15, f_yr,  0, 49, 0,   0,  0,    hm,     0,  true, f_utc1+hm   );
+    testParse (t, "2013-12-06T12:34:56+01:00", 25, year, mo,  0, wks,   0,  6,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-12-06T12:34:56+01",    22, year, mo,  0, wks,   0,  6,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-12-06T12:34:56-01:00", 25, year, mo,  0, wks,   0,  6,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-12-06T12:34:56-01",    22, year, mo,  0, wks,   0,  6,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-12-06T12:34+01:00",    22, year, mo,  0, wks,   0,  6,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-12-06T12:34+01",       19, year, mo,  0, wks,   0,  6,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-12-06T12:34-01:00",    22, year, mo,  0, wks,   0,  6,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-12-06T12:34-01",       19, year, mo,  0, wks,   0,  6,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-340T12:34:56+01:00",   23, year,  0,  0, wks, 340,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-340T12:34:56+01",      20, year,  0,  0, wks, 340,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-340T12:34:56-01:00",   23, year,  0,  0, wks, 340,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-340T12:34:56-01",      20, year,  0,  0, wks, 340,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-340T12:34+01:00",      20, year,  0,  0, wks, 340,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-340T12:34+01",         17, year,  0,  0, wks, 340,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-340T12:34-01:00",      20, year,  0,  0, wks, 340,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-340T12:34-01",         17, year,  0,  0, wks, 340,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-W49-5T12:34:56+01:00", 25, year,  0, 49, 5,     0,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-W49-5T12:34:56+01",    22, year,  0, 49, 5,     0,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013-W49-5T12:34:56-01:00", 25, year,  0, 49, 5,     0,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-W49-5T12:34:56-01",    22, year,  0, 49, 5,     0,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013-W49-5T12:34+01:00",    22, year,  0, 49, 5,     0,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-W49-5T12:34+01",       19, year,  0, 49, 5,     0,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013-W49-5T12:34-01:00",    22, year,  0, 49, 5,     0,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-W49-5T12:34-01",       19, year,  0, 49, 5,     0,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013-W49T12:34:56+01:00",   23, year,  0, 49, wks,   0,  0,   hms,  3600, false, utc1+hms-z);
+    testParse (t, "2013-W49T12:34:56+01",      20, year,  0, 49, wks,   0,  0,   hms,  3600, false, utc1+hms-z);
+    testParse (t, "2013-W49T12:34:56-01:00",   23, year,  0, 49, wks,   0,  0,   hms, -3600, false, utc1+hms+z);
+    testParse (t, "2013-W49T12:34:56-01",      20, year,  0, 49, wks,   0,  0,   hms, -3600, false, utc1+hms+z);
+    testParse (t, "2013-W49T12:34+01:00",      20, year,  0, 49, wks,   0,  0,    hm,  3600, false, utc1+hm-z );
+    testParse (t, "2013-W49T12:34+01",         17, year,  0, 49, wks,   0,  0,    hm,  3600, false, utc1+hm-z );
+    testParse (t, "2013-W49T12:34-01:00",      20, year,  0, 49, wks,   0,  0,    hm, -3600, false, utc1+hm+z );
+    testParse (t, "2013-W49T12:34-01",         17, year,  0, 49, wks,   0,  0,    hm, -3600, false, utc1+hm+z );
 
-  testParse (t, "9850-12-06T12:34:56+01:00", 25, f_yr, mo,  0, 0,   0,  6,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-12-06T12:34:56+01",    22, f_yr, mo,  0, 0,   0,  6,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-12-06T12:34:56-01:00", 25, f_yr, mo,  0, 0,   0,  6,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-12-06T12:34:56-01",    22, f_yr, mo,  0, 0,   0,  6,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-12-06T12:34+01:00",    22, f_yr, mo,  0, 0,   0,  6,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-12-06T12:34+01",       19, f_yr, mo,  0, 0,   0,  6,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-12-06T12:34-01:00",    22, f_yr, mo,  0, 0,   0,  6,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-12-06T12:34-01",       19, f_yr, mo,  0, 0,   0,  6,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-340T12:34:56+01:00",   23, f_yr,  0,  0, 0, 340,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-340T12:34:56+01",      20, f_yr,  0,  0, 0, 340,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-340T12:34:56-01:00",   23, f_yr,  0,  0, 0, 340,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-340T12:34:56-01",      20, f_yr,  0,  0, 0, 340,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-340T12:34+01:00",      20, f_yr,  0,  0, 0, 340,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-340T12:34+01",         17, f_yr,  0,  0, 0, 340,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-340T12:34-01:00",      20, f_yr,  0,  0, 0, 340,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-340T12:34-01",         17, f_yr,  0,  0, 0, 340,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-W49-5T12:34:56+01:00", 25, f_yr,  0, 49, 5,   0,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-W49-5T12:34:56+01",    22, f_yr,  0, 49, 5,   0,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850-W49-5T12:34:56-01:00", 25, f_yr,  0, 49, 5,   0,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-W49-5T12:34:56-01",    22, f_yr,  0, 49, 5,   0,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850-W49-5T12:34+01:00",    22, f_yr,  0, 49, 5,   0,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-W49-5T12:34+01",       19, f_yr,  0, 49, 5,   0,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850-W49-5T12:34-01:00",    22, f_yr,  0, 49, 5,   0,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-W49-5T12:34-01",       19, f_yr,  0, 49, 5,   0,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850-W49T12:34:56+01:00",   23, f_yr,  0, 49, 0,   0,  0,   hms,  3600, false, f_utc1+hms-z);
-  testParse (t, "9850-W49T12:34:56+01",      20, f_yr,  0, 49, 0,   0,  0,   hms,  3600, false, f_utc1+hms-z);
-  testParse (t, "9850-W49T12:34:56-01:00",   23, f_yr,  0, 49, 0,   0,  0,   hms, -3600, false, f_utc1+hms+z);
-  testParse (t, "9850-W49T12:34:56-01",      20, f_yr,  0, 49, 0,   0,  0,   hms, -3600, false, f_utc1+hms+z);
-  testParse (t, "9850-W49T12:34+01:00",      20, f_yr,  0, 49, 0,   0,  0,    hm,  3600, false, f_utc1+hm-z );
-  testParse (t, "9850-W49T12:34+01",         17, f_yr,  0, 49, 0,   0,  0,    hm,  3600, false, f_utc1+hm-z );
-  testParse (t, "9850-W49T12:34-01:00",      20, f_yr,  0, 49, 0,   0,  0,    hm, -3600, false, f_utc1+hm+z );
-  testParse (t, "9850-W49T12:34-01",         17, f_yr,  0, 49, 0,   0,  0,    hm, -3600, false, f_utc1+hm+z );
+    // datetime-ext in the future
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "9850-12-06",                10, f_yr, mo,  0, wks,   0,  6,     0,     0, false, f_local6    );
+    testParse (t, "9850-340",                   8, f_yr,  0,  0, wks, 340,  0,     0,     0, false, f_local6    );
+    testParse (t, "9850-W49-5",                10, f_yr,  0, 49, 5,     0,  0,     0,     0, false, f_local6    );
+    testParse (t, "9850-W49",                   8, f_yr,  0, 49, wks,   0,  0,     0,     0, false, f_local1    );
+    testParse (t, "9850-12",                    7, f_yr, mo,  0, wks,   0,  1,     0,     0, false, f_local1 - 86400 * wks);
 
-  // The only non-extended forms.
-  testParse (t, "20131206T123456Z",          16, year, mo,  0, 0,   0,  6,   hms,     0,  true, utc6+hms  );
-  testParse (t, "20131206T123456",           15, year, mo,  0, 0,   0,  6,   hms,     0, false, local6+hms);
+    testParse (t, "9850-12-06T12:34:56",       19, f_yr, mo,  0, wks,   0,  6,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850-12-06T12:34",          16, f_yr, mo,  0, wks,   0,  6,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850-340T12:34:56",         17, f_yr,  0,  0, wks, 340,  0,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850-340T12:34",            14, f_yr,  0,  0, wks, 340,  0,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850-W49-5T12:34:56",       19, f_yr,  0, 49, 5,     0,  0,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850-W49-5T12:34",          16, f_yr,  0, 49, 5,     0,  0,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850-W49T12:34:56",         17, f_yr,  0, 49, wks,   0,  0,   hms,     0, false, f_local1+hms);
+    testParse (t, "9850-W49T12:34",            14, f_yr,  0, 49, wks,   0,  0,    hm,     0, false, f_local1+hm );
 
-  // The only non-extended forms - future
-  testParse (t, "98501206T123456Z",          16, f_yr, mo,  0, 0,   0,  6,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "98501206T123456",           15, f_yr, mo,  0, 0,   0,  6,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850-12-06T12:34:56Z",      20, f_yr, mo,  0, wks,   0,  6,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "9850-12-06T12:34Z",         17, f_yr, mo,  0, wks,   0,  6,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850-340T12:34:56Z",        18, f_yr,  0,  0, wks, 340,  0,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "9850-340T12:34Z",           15, f_yr,  0,  0, wks, 340,  0,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850-W49-5T12:34:56Z",      20, f_yr,  0, 49, 5,     0,  0,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "9850-W49-5T12:34Z",         17, f_yr,  0, 49, 5,     0,  0,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850-W49T12:34:56Z",        18, f_yr,  0, 49, wks,   0,  0,   hms,     0,  true, f_utc1+hms  );
+    testParse (t, "9850-W49T12:34Z",           15, f_yr,  0, 49, wks,   0,  0,    hm,     0,  true, f_utc1+hm   );
 
-  // Non-extended forms.
+    testParse (t, "9850-12-06T12:34:56+01:00", 25, f_yr, mo,  0, wks,   0,  6,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-12-06T12:34:56+01",    22, f_yr, mo,  0, wks,   0,  6,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-12-06T12:34:56-01:00", 25, f_yr, mo,  0, wks,   0,  6,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-12-06T12:34:56-01",    22, f_yr, mo,  0, wks,   0,  6,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-12-06T12:34+01:00",    22, f_yr, mo,  0, wks,   0,  6,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-12-06T12:34+01",       19, f_yr, mo,  0, wks,   0,  6,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-12-06T12:34-01:00",    22, f_yr, mo,  0, wks,   0,  6,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-12-06T12:34-01",       19, f_yr, mo,  0, wks,   0,  6,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-340T12:34:56+01:00",   23, f_yr,  0,  0, wks, 340,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-340T12:34:56+01",      20, f_yr,  0,  0, wks, 340,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-340T12:34:56-01:00",   23, f_yr,  0,  0, wks, 340,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-340T12:34:56-01",      20, f_yr,  0,  0, wks, 340,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-340T12:34+01:00",      20, f_yr,  0,  0, wks, 340,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-340T12:34+01",         17, f_yr,  0,  0, wks, 340,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-340T12:34-01:00",      20, f_yr,  0,  0, wks, 340,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-340T12:34-01",         17, f_yr,  0,  0, wks, 340,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-W49-5T12:34:56+01:00", 25, f_yr,  0, 49, 5,     0,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-W49-5T12:34:56+01",    22, f_yr,  0, 49, 5,     0,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850-W49-5T12:34:56-01:00", 25, f_yr,  0, 49, 5,     0,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-W49-5T12:34:56-01",    22, f_yr,  0, 49, 5,     0,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850-W49-5T12:34+01:00",    22, f_yr,  0, 49, 5,     0,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-W49-5T12:34+01",       19, f_yr,  0, 49, 5,     0,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850-W49-5T12:34-01:00",    22, f_yr,  0, 49, 5,     0,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-W49-5T12:34-01",       19, f_yr,  0, 49, 5,     0,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850-W49T12:34:56+01:00",   23, f_yr,  0, 49, wks,   0,  0,   hms,  3600, false, f_utc1+hms-z);
+    testParse (t, "9850-W49T12:34:56+01",      20, f_yr,  0, 49, wks,   0,  0,   hms,  3600, false, f_utc1+hms-z);
+    testParse (t, "9850-W49T12:34:56-01:00",   23, f_yr,  0, 49, wks,   0,  0,   hms, -3600, false, f_utc1+hms+z);
+    testParse (t, "9850-W49T12:34:56-01",      20, f_yr,  0, 49, wks,   0,  0,   hms, -3600, false, f_utc1+hms+z);
+    testParse (t, "9850-W49T12:34+01:00",      20, f_yr,  0, 49, wks,   0,  0,    hm,  3600, false, f_utc1+hm-z );
+    testParse (t, "9850-W49T12:34+01",         17, f_yr,  0, 49, wks,   0,  0,    hm,  3600, false, f_utc1+hm-z );
+    testParse (t, "9850-W49T12:34-01:00",      20, f_yr,  0, 49, wks,   0,  0,    hm, -3600, false, f_utc1+hm+z );
+    testParse (t, "9850-W49T12:34-01",         17, f_yr,  0, 49, wks,   0,  0,    hm, -3600, false, f_utc1+hm+z );
 
-  // time
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "123456Z",                    7,    0,  0,  0, 0,   0,  0,   hms,     0,  true, utc+hms+ud   );
-  testParse (t, "1234Z",                      5,    0,  0,  0, 0,   0,  0,    hm,     0,  true, utc+hm+ud    );
-  testParse (t, "123456+0100",               11,    0,  0,  0, 0,   0,  0,   hms,  3600, false, utc+hms-z+ud );
-  testParse (t, "123456+01",                  9,    0,  0,  0, 0,   0,  0,   hms,  3600, false, utc+hms-z+ud );
-  testParse (t, "1234+0100",                  9,    0,  0,  0, 0,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
-  testParse (t, "1234+01",                    7,    0,  0,  0, 0,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
-  testParse (t, "123456",                     6,    0,  0,  0, 0,   0,  0,   hms,     0, false, local+hms+ld );
-  testParse (t, "1234",                       4,    0,  0,  0, 0,   0,  0,    hm,     0, false, local+hm+ld  );
+    // The only non-extended forms.
+    testParse (t, "20131206T123456Z",          16, year, mo,  0, wks,   0,  6,   hms,     0,  true, utc6+hms  );
+    testParse (t, "20131206T123456",           15, year, mo,  0, wks,   0,  6,   hms,     0, false, local6+hms);
 
-  // datetime
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "20131206",                   8, year, mo,  0, 0,   0,  6,     0,     0, false, local6    );
-  testParse (t, "2013340",                    7, year,  0,  0, 0, 340,  0,     0,     0, false, local6    );
-  testParse (t, "2013W495",                   8, year,  0, 49, 5,   0,  0,     0,     0, false, local6    );
-  testParse (t, "2013W49",                    7, year,  0, 49, 0,   0,  0,     0,     0, false, local1    );
-  testParse (t, "201312",                     6, year, mo,  0, 0,   0,  1,     0,     0, false, local1    );
+    // The only non-extended forms - future
+    testParse (t, "98501206T123456Z",          16, f_yr, mo,  0, wks,   0,  6,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "98501206T123456",           15, f_yr, mo,  0, wks,   0,  6,   hms,     0, false, f_local6+hms);
 
-  testParse (t, "20131206T123456",           15, year, mo,  0, 0,   0,  6,   hms,     0, false, local6+hms);
-  testParse (t, "20131206T1234",             13, year, mo,  0, 0,   0,  6,    hm,     0, false, local6+hm );
-  testParse (t, "2013340T123456",            14, year,  0,  0, 0, 340,  0,   hms,     0, false, local6+hms);
-  testParse (t, "2013340T1234",              12, year,  0,  0, 0, 340,  0,    hm,     0, false, local6+hm );
-  testParse (t, "2013W495T123456",           15, year,  0, 49, 5,   0,  0,   hms,     0, false, local6+hms);
-  testParse (t, "2013W495T1234",             13, year,  0, 49, 5,   0,  0,    hm,     0, false, local6+hm );
-  testParse (t, "2013W49T123456",            14, year,  0, 49, 0,   0,  0,   hms,     0, false, local1+hms);
-  testParse (t, "2013W49T1234",              12, year,  0, 49, 0,   0,  0,    hm,     0, false, local1+hm );
+    // Non-extended forms.
 
-  testParse (t, "20131206T123456Z",          16, year, mo,  0, 0,   0,  6,   hms,     0,  true, utc6+hms  );
-  testParse (t, "20131206T1234Z",            14, year, mo,  0, 0,   0,  6,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013340T123456Z",           15, year,  0,  0, 0, 340,  0,   hms,     0,  true, utc6+hms  );
-  testParse (t, "2013340T1234Z",             13, year,  0,  0, 0, 340,  0,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013W495T123456Z",          16, year,  0, 49, 5,   0,  0,   hms,     0,  true, utc6+hms  );
-  testParse (t, "2013W495T1234Z",            14, year,  0, 49, 5,   0,  0,    hm,     0,  true, utc6+hm   );
-  testParse (t, "2013W49T123456Z",           15, year,  0, 49, 0,   0,  0,   hms,     0,  true, utc1+hms  );
-  testParse (t, "2013W49T1234Z",             13, year,  0, 49, 0,   0,  0,    hm,     0,  true, utc1+hm   );
+    // time
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "123456Z",                    7,    0,  0,  0, wks,   0,  0,   hms,     0,  true, utc+hms+ud   );
+    testParse (t, "1234Z",                      5,    0,  0,  0, wks,   0,  0,    hm,     0,  true, utc+hm+ud    );
+    testParse (t, "123456+0100",               11,    0,  0,  0, wks,   0,  0,   hms,  3600, false, utc+hms-z+ud );
+    testParse (t, "123456+01",                  9,    0,  0,  0, wks,   0,  0,   hms,  3600, false, utc+hms-z+ud );
+    testParse (t, "1234+0100",                  9,    0,  0,  0, wks,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
+    testParse (t, "1234+01",                    7,    0,  0,  0, wks,   0,  0,    hm,  3600, false, utc+hm-z+ud  );
+    testParse (t, "123456",                     6,    0,  0,  0, wks,   0,  0,   hms,     0, false, local+hms+ld );
+    testParse (t, "1234",                       4,    0,  0,  0, wks,   0,  0,    hm,     0, false, local+hm+ld  );
 
-  testParse (t, "20131206T123456+0100",      20, year, mo,  0, 0,   0,  6,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "20131206T123456+01",        18, year, mo,  0, 0,   0,  6,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "20131206T123456-0100",      20, year, mo,  0, 0,   0,  6,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "20131206T123456-01",        18, year, mo,  0, 0,   0,  6,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "20131206T1234+0100",        18, year, mo,  0, 0,   0,  6,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "20131206T1234+01",          16, year, mo,  0, 0,   0,  6,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "20131206T1234-0100",        18, year, mo,  0, 0,   0,  6,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "20131206T1234-01",          16, year, mo,  0, 0,   0,  6,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013340T123456+0100",       19, year,  0,  0, 0, 340,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013340T123456+01",         17, year,  0,  0, 0, 340,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013340T123456-0100",       19, year,  0,  0, 0, 340,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013340T123456-01",         17, year,  0,  0, 0, 340,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013340T1234+0100",         17, year,  0,  0, 0, 340,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013340T1234+01",           15, year,  0,  0, 0, 340,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013340T1234-0100",         17, year,  0,  0, 0, 340,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013340T1234-01",           15, year,  0,  0, 0, 340,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013W495T123456+0100",      20, year,  0, 49, 5,   0,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013W495T123456+01",        18, year,  0, 49, 5,   0,  0,   hms,  3600, false, utc6+hms-z);
-  testParse (t, "2013W495T123456-0100",      20, year,  0, 49, 5,   0,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013W495T123456-01",        18, year,  0, 49, 5,   0,  0,   hms, -3600, false, utc6+hms+z);
-  testParse (t, "2013W495T1234+0100",        18, year,  0, 49, 5,   0,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013W495T1234+01",          16, year,  0, 49, 5,   0,  0,    hm,  3600, false, utc6+hm-z );
-  testParse (t, "2013W495T1234-0100",        18, year,  0, 49, 5,   0,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013W495T1234-01",          16, year,  0, 49, 5,   0,  0,    hm, -3600, false, utc6+hm+z );
-  testParse (t, "2013W49T123456+0100",       19, year,  0, 49, 0,   0,  0,   hms,  3600, false, utc1+hms-z);
-  testParse (t, "2013W49T123456+01",         17, year,  0, 49, 0,   0,  0,   hms,  3600, false, utc1+hms-z);
-  testParse (t, "2013W49T123456-0100",       19, year,  0, 49, 0,   0,  0,   hms, -3600, false, utc1+hms+z);
-  testParse (t, "2013W49T123456-01",         17, year,  0, 49, 0,   0,  0,   hms, -3600, false, utc1+hms+z);
-  testParse (t, "2013W49T1234+0100",         17, year,  0, 49, 0,   0,  0,    hm,  3600, false, utc1+hm-z );
-  testParse (t, "2013W49T1234+01",           15, year,  0, 49, 0,   0,  0,    hm,  3600, false, utc1+hm-z );
-  testParse (t, "2013W49T1234-0100",         17, year,  0, 49, 0,   0,  0,    hm, -3600, false, utc1+hm+z );
-  testParse (t, "2013W49T1234-01",           15, year,  0, 49, 0,   0,  0,    hm, -3600, false, utc1+hm+z );
+    // datetime
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "20131206",                   8, year, mo,  0, wks,   0,  6,     0,     0, false, local6    );
+    testParse (t, "2013340",                    7, year,  0,  0, wks, 340,  0,     0,     0, false, local6    );
+    testParse (t, "2013W495",                   8, year,  0, 49, 5,     0,  0,     0,     0, false, local6    );
+    testParse (t, "2013W49",                    7, year,  0, 49, wks,   0,  0,     0,     0, false, local1    );
+    testParse (t, "201312",                     6, year, mo,  0, wks,   0,  1,     0,     0, false, local1 - 86400 * wks);
 
-  // datetime - future
-  //            input                         i  Year  Mo  Wk WD  Jul  Da   Secs     TZ    UTC      time_t
-  testParse (t, "98501206",                   8, f_yr, mo,  0, 0,   0,  6,     0,     0, false, f_local6    );
-  testParse (t, "9850340",                    7, f_yr,  0,  0, 0, 340,  0,     0,     0, false, f_local6    );
-  testParse (t, "9850W495",                   8, f_yr,  0, 49, 5,   0,  0,     0,     0, false, f_local6    );
-  testParse (t, "9850W49",                    7, f_yr,  0, 49, 0,   0,  0,     0,     0, false, f_local1    );
-  testParse (t, "985012",                     6, f_yr, mo,  0, 0,   0,  1,     0,     0, false, f_local1    );
+    testParse (t, "20131206T123456",           15, year, mo,  0, wks,   0,  6,   hms,     0, false, local6+hms);
+    testParse (t, "20131206T1234",             13, year, mo,  0, wks,   0,  6,    hm,     0, false, local6+hm );
+    testParse (t, "2013340T123456",            14, year,  0,  0, wks, 340,  0,   hms,     0, false, local6+hms);
+    testParse (t, "2013340T1234",              12, year,  0,  0, wks, 340,  0,    hm,     0, false, local6+hm );
+    testParse (t, "2013W495T123456",           15, year,  0, 49, 5,     0,  0,   hms,     0, false, local6+hms);
+    testParse (t, "2013W495T1234",             13, year,  0, 49, 5,     0,  0,    hm,     0, false, local6+hm );
+    testParse (t, "2013W49T123456",            14, year,  0, 49, wks,   0,  0,   hms,     0, false, local1+hms);
+    testParse (t, "2013W49T1234",              12, year,  0, 49, wks,   0,  0,    hm,     0, false, local1+hm );
 
-  testParse (t, "98501206T123456",           15, f_yr, mo,  0, 0,   0,  6,   hms,     0, false, f_local6+hms);
-  testParse (t, "98501206T1234",             13, f_yr, mo,  0, 0,   0,  6,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850340T123456",            14, f_yr,  0,  0, 0, 340,  0,   hms,     0, false, f_local6+hms);
-  testParse (t, "9850340T1234",              12, f_yr,  0,  0, 0, 340,  0,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850W495T123456",           15, f_yr,  0, 49, 5,   0,  0,   hms,     0, false, f_local6+hms);
-  testParse (t, "9850W495T1234",             13, f_yr,  0, 49, 5,   0,  0,    hm,     0, false, f_local6+hm );
-  testParse (t, "9850W49T123456",            14, f_yr,  0, 49, 0,   0,  0,   hms,     0, false, f_local1+hms);
-  testParse (t, "9850W49T1234",              12, f_yr,  0, 49, 0,   0,  0,    hm,     0, false, f_local1+hm );
+    testParse (t, "20131206T123456Z",          16, year, mo,  0, wks,   0,  6,   hms,     0,  true, utc6+hms  );
+    testParse (t, "20131206T1234Z",            14, year, mo,  0, wks,   0,  6,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013340T123456Z",           15, year,  0,  0, wks, 340,  0,   hms,     0,  true, utc6+hms  );
+    testParse (t, "2013340T1234Z",             13, year,  0,  0, wks, 340,  0,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013W495T123456Z",          16, year,  0, 49, 5,     0,  0,   hms,     0,  true, utc6+hms  );
+    testParse (t, "2013W495T1234Z",            14, year,  0, 49, 5,     0,  0,    hm,     0,  true, utc6+hm   );
+    testParse (t, "2013W49T123456Z",           15, year,  0, 49, wks,   0,  0,   hms,     0,  true, utc1+hms  );
+    testParse (t, "2013W49T1234Z",             13, year,  0, 49, wks,   0,  0,    hm,     0,  true, utc1+hm   );
 
-  testParse (t, "98501206T123456Z",          16, f_yr, mo,  0, 0,   0,  6,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "98501206T1234Z",            14, f_yr, mo,  0, 0,   0,  6,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850340T123456Z",           15, f_yr,  0,  0, 0, 340,  0,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "9850340T1234Z",             13, f_yr,  0,  0, 0, 340,  0,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850W495T123456Z",          16, f_yr,  0, 49, 5,   0,  0,   hms,     0,  true, f_utc6+hms  );
-  testParse (t, "9850W495T1234Z",            14, f_yr,  0, 49, 5,   0,  0,    hm,     0,  true, f_utc6+hm   );
-  testParse (t, "9850W49T123456Z",           15, f_yr,  0, 49, 0,   0,  0,   hms,     0,  true, f_utc1+hms  );
-  testParse (t, "9850W49T1234Z",             13, f_yr,  0, 49, 0,   0,  0,    hm,     0,  true, f_utc1+hm   );
+    testParse (t, "20131206T123456+0100",      20, year, mo,  0, wks,   0,  6,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "20131206T123456+01",        18, year, mo,  0, wks,   0,  6,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "20131206T123456-0100",      20, year, mo,  0, wks,   0,  6,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "20131206T123456-01",        18, year, mo,  0, wks,   0,  6,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "20131206T1234+0100",        18, year, mo,  0, wks,   0,  6,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "20131206T1234+01",          16, year, mo,  0, wks,   0,  6,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "20131206T1234-0100",        18, year, mo,  0, wks,   0,  6,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "20131206T1234-01",          16, year, mo,  0, wks,   0,  6,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013340T123456+0100",       19, year,  0,  0, wks, 340,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013340T123456+01",         17, year,  0,  0, wks, 340,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013340T123456-0100",       19, year,  0,  0, wks, 340,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013340T123456-01",         17, year,  0,  0, wks, 340,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013340T1234+0100",         17, year,  0,  0, wks, 340,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013340T1234+01",           15, year,  0,  0, wks, 340,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013340T1234-0100",         17, year,  0,  0, wks, 340,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013340T1234-01",           15, year,  0,  0, wks, 340,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013W495T123456+0100",      20, year,  0, 49, 5,     0,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013W495T123456+01",        18, year,  0, 49, 5,     0,  0,   hms,  3600, false, utc6+hms-z);
+    testParse (t, "2013W495T123456-0100",      20, year,  0, 49, 5,     0,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013W495T123456-01",        18, year,  0, 49, 5,     0,  0,   hms, -3600, false, utc6+hms+z);
+    testParse (t, "2013W495T1234+0100",        18, year,  0, 49, 5,     0,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013W495T1234+01",          16, year,  0, 49, 5,     0,  0,    hm,  3600, false, utc6+hm-z );
+    testParse (t, "2013W495T1234-0100",        18, year,  0, 49, 5,     0,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013W495T1234-01",          16, year,  0, 49, 5,     0,  0,    hm, -3600, false, utc6+hm+z );
+    testParse (t, "2013W49T123456+0100",       19, year,  0, 49, wks,   0,  0,   hms,  3600, false, utc1+hms-z);
+    testParse (t, "2013W49T123456+01",         17, year,  0, 49, wks,   0,  0,   hms,  3600, false, utc1+hms-z);
+    testParse (t, "2013W49T123456-0100",       19, year,  0, 49, wks,   0,  0,   hms, -3600, false, utc1+hms+z);
+    testParse (t, "2013W49T123456-01",         17, year,  0, 49, wks,   0,  0,   hms, -3600, false, utc1+hms+z);
+    testParse (t, "2013W49T1234+0100",         17, year,  0, 49, wks,   0,  0,    hm,  3600, false, utc1+hm-z );
+    testParse (t, "2013W49T1234+01",           15, year,  0, 49, wks,   0,  0,    hm,  3600, false, utc1+hm-z );
+    testParse (t, "2013W49T1234-0100",         17, year,  0, 49, wks,   0,  0,    hm, -3600, false, utc1+hm+z );
+    testParse (t, "2013W49T1234-01",           15, year,  0, 49, wks,   0,  0,    hm, -3600, false, utc1+hm+z );
 
-  testParse (t, "98501206T123456+0100",      20, f_yr, mo,  0, 0,   0,  6,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "98501206T123456+01",        18, f_yr, mo,  0, 0,   0,  6,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "98501206T123456-0100",      20, f_yr, mo,  0, 0,   0,  6,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "98501206T123456-01",        18, f_yr, mo,  0, 0,   0,  6,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "98501206T1234+0100",        18, f_yr, mo,  0, 0,   0,  6,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "98501206T1234+01",          16, f_yr, mo,  0, 0,   0,  6,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "98501206T1234-0100",        18, f_yr, mo,  0, 0,   0,  6,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "98501206T1234-01",          16, f_yr, mo,  0, 0,   0,  6,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850340T123456+0100",       19, f_yr,  0,  0, 0, 340,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850340T123456+01",         17, f_yr,  0,  0, 0, 340,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850340T123456-0100",       19, f_yr,  0,  0, 0, 340,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850340T123456-01",         17, f_yr,  0,  0, 0, 340,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850340T1234+0100",         17, f_yr,  0,  0, 0, 340,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850340T1234+01",           15, f_yr,  0,  0, 0, 340,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850340T1234-0100",         17, f_yr,  0,  0, 0, 340,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850340T1234-01",           15, f_yr,  0,  0, 0, 340,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850W495T123456+0100",      20, f_yr,  0, 49, 5,   0,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850W495T123456+01",        18, f_yr,  0, 49, 5,   0,  0,   hms,  3600, false, f_utc6+hms-z);
-  testParse (t, "9850W495T123456-0100",      20, f_yr,  0, 49, 5,   0,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850W495T123456-01",        18, f_yr,  0, 49, 5,   0,  0,   hms, -3600, false, f_utc6+hms+z);
-  testParse (t, "9850W495T1234+0100",        18, f_yr,  0, 49, 5,   0,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850W495T1234+01",          16, f_yr,  0, 49, 5,   0,  0,    hm,  3600, false, f_utc6+hm-z );
-  testParse (t, "9850W495T1234-0100",        18, f_yr,  0, 49, 5,   0,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850W495T1234-01",          16, f_yr,  0, 49, 5,   0,  0,    hm, -3600, false, f_utc6+hm+z );
-  testParse (t, "9850W49T123456+0100",       19, f_yr,  0, 49, 0,   0,  0,   hms,  3600, false, f_utc1+hms-z);
-  testParse (t, "9850W49T123456+01",         17, f_yr,  0, 49, 0,   0,  0,   hms,  3600, false, f_utc1+hms-z);
-  testParse (t, "9850W49T123456-0100",       19, f_yr,  0, 49, 0,   0,  0,   hms, -3600, false, f_utc1+hms+z);
-  testParse (t, "9850W49T123456-01",         17, f_yr,  0, 49, 0,   0,  0,   hms, -3600, false, f_utc1+hms+z);
-  testParse (t, "9850W49T1234+0100",         17, f_yr,  0, 49, 0,   0,  0,    hm,  3600, false, f_utc1+hm-z );
-  testParse (t, "9850W49T1234+01",           15, f_yr,  0, 49, 0,   0,  0,    hm,  3600, false, f_utc1+hm-z );
-  testParse (t, "9850W49T1234-0100",         17, f_yr,  0, 49, 0,   0,  0,    hm, -3600, false, f_utc1+hm+z );
-  testParse (t, "9850W49T1234-01",           15, f_yr,  0, 49, 0,   0,  0,    hm, -3600, false, f_utc1+hm+z );
+    // datetime - future
+    //            input                         i  Year  Mo  Wk   WD  Jul  Da   Secs     TZ    UTC      time_t
+    testParse (t, "98501206",                   8, f_yr, mo,  0, wks,   0,  6,     0,     0, false, f_local6    );
+    testParse (t, "9850340",                    7, f_yr,  0,  0, wks, 340,  0,     0,     0, false, f_local6    );
+    testParse (t, "9850W495",                   8, f_yr,  0, 49, 5,     0,  0,     0,     0, false, f_local6    );
+    testParse (t, "9850W49",                    7, f_yr,  0, 49, wks,   0,  0,     0,     0, false, f_local1    );
+    testParse (t, "985012",                     6, f_yr, mo,  0, wks,   0,  1,     0,     0, false, f_local1 - 86400 * wks);
 
-  // Informal time.
-  int t8a   = (8 * 3600);
-  int t830a = (8 * 3600) + (30 * 60);
-  int t8p   = (20 * 3600);
-  int t830p = (20 * 3600) + (30 * 60);
-  int t12p  = (12 * 3600);
-  int t1p   = (13 * 3600);
+    testParse (t, "98501206T123456",           15, f_yr, mo,  0, wks,   0,  6,   hms,     0, false, f_local6+hms);
+    testParse (t, "98501206T1234",             13, f_yr, mo,  0, wks,   0,  6,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850340T123456",            14, f_yr,  0,  0, wks, 340,  0,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850340T1234",              12, f_yr,  0,  0, wks, 340,  0,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850W495T123456",           15, f_yr,  0, 49, 5,     0,  0,   hms,     0, false, f_local6+hms);
+    testParse (t, "9850W495T1234",             13, f_yr,  0, 49, 5,     0,  0,    hm,     0, false, f_local6+hm );
+    testParse (t, "9850W49T123456",            14, f_yr,  0, 49, wks,   0,  0,   hms,     0, false, f_local1+hms);
+    testParse (t, "9850W49T1234",              12, f_yr,  0, 49, wks,   0,  0,    hm,     0, false, f_local1+hm );
 
-  Datetime time_now;
-  int adjust = (time_now.hour () > 10 || (time_now.hour () == 10 && time_now.minute () > 30)) ? 86400 : 0;
-  testParse (t, "10:30am",                    7,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830a+adjust+(2*3600));
+    testParse (t, "98501206T123456Z",          16, f_yr, mo,  0, wks,   0,  6,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "98501206T1234Z",            14, f_yr, mo,  0, wks,   0,  6,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850340T123456Z",           15, f_yr,  0,  0, wks, 340,  0,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "9850340T1234Z",             13, f_yr,  0,  0, wks, 340,  0,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850W495T123456Z",          16, f_yr,  0, 49, 5,     0,  0,   hms,     0,  true, f_utc6+hms  );
+    testParse (t, "9850W495T1234Z",            14, f_yr,  0, 49, 5,     0,  0,    hm,     0,  true, f_utc6+hm   );
+    testParse (t, "9850W49T123456Z",           15, f_yr,  0, 49, wks,   0,  0,   hms,     0,  true, f_utc1+hms  );
+    testParse (t, "9850W49T1234Z",             13, f_yr,  0, 49, wks,   0,  0,    hm,     0,  true, f_utc1+hm   );
 
-  adjust = (time_now.hour () > 8 || (time_now.hour () == 8 && time_now.minute () > 30)) ? 86400 : 0;
-  testParse (t, "8:30am",                     6,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830a+adjust);
-  testParse (t, "8:30a",                      5,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830a+adjust);
-  testParse (t, "8:30",                       4,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830a+adjust);
+    testParse (t, "98501206T123456+0100",      20, f_yr, mo,  0, wks,   0,  6,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "98501206T123456+01",        18, f_yr, mo,  0, wks,   0,  6,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "98501206T123456-0100",      20, f_yr, mo,  0, wks,   0,  6,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "98501206T123456-01",        18, f_yr, mo,  0, wks,   0,  6,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "98501206T1234+0100",        18, f_yr, mo,  0, wks,   0,  6,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "98501206T1234+01",          16, f_yr, mo,  0, wks,   0,  6,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "98501206T1234-0100",        18, f_yr, mo,  0, wks,   0,  6,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "98501206T1234-01",          16, f_yr, mo,  0, wks,   0,  6,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850340T123456+0100",       19, f_yr,  0,  0, wks, 340,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850340T123456+01",         17, f_yr,  0,  0, wks, 340,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850340T123456-0100",       19, f_yr,  0,  0, wks, 340,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850340T123456-01",         17, f_yr,  0,  0, wks, 340,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850340T1234+0100",         17, f_yr,  0,  0, wks, 340,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850340T1234+01",           15, f_yr,  0,  0, wks, 340,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850340T1234-0100",         17, f_yr,  0,  0, wks, 340,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850340T1234-01",           15, f_yr,  0,  0, wks, 340,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850W495T123456+0100",      20, f_yr,  0, 49, 5,     0,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850W495T123456+01",        18, f_yr,  0, 49, 5,     0,  0,   hms,  3600, false, f_utc6+hms-z);
+    testParse (t, "9850W495T123456-0100",      20, f_yr,  0, 49, 5,     0,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850W495T123456-01",        18, f_yr,  0, 49, 5,     0,  0,   hms, -3600, false, f_utc6+hms+z);
+    testParse (t, "9850W495T1234+0100",        18, f_yr,  0, 49, 5,     0,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850W495T1234+01",          16, f_yr,  0, 49, 5,     0,  0,    hm,  3600, false, f_utc6+hm-z );
+    testParse (t, "9850W495T1234-0100",        18, f_yr,  0, 49, 5,     0,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850W495T1234-01",          16, f_yr,  0, 49, 5,     0,  0,    hm, -3600, false, f_utc6+hm+z );
+    testParse (t, "9850W49T123456+0100",       19, f_yr,  0, 49, wks,   0,  0,   hms,  3600, false, f_utc1+hms-z);
+    testParse (t, "9850W49T123456+01",         17, f_yr,  0, 49, wks,   0,  0,   hms,  3600, false, f_utc1+hms-z);
+    testParse (t, "9850W49T123456-0100",       19, f_yr,  0, 49, wks,   0,  0,   hms, -3600, false, f_utc1+hms+z);
+    testParse (t, "9850W49T123456-01",         17, f_yr,  0, 49, wks,   0,  0,   hms, -3600, false, f_utc1+hms+z);
+    testParse (t, "9850W49T1234+0100",         17, f_yr,  0, 49, wks,   0,  0,    hm,  3600, false, f_utc1+hm-z );
+    testParse (t, "9850W49T1234+01",           15, f_yr,  0, 49, wks,   0,  0,    hm,  3600, false, f_utc1+hm-z );
+    testParse (t, "9850W49T1234-0100",         17, f_yr,  0, 49, wks,   0,  0,    hm, -3600, false, f_utc1+hm+z );
+    testParse (t, "9850W49T1234-01",           15, f_yr,  0, 49, wks,   0,  0,    hm, -3600, false, f_utc1+hm+z );
 
-  adjust = (time_now.hour () >= 8) ? 86400 : 0;
-  testParse (t, "8am",                        3,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t8a+adjust);
-  testParse (t, "8a",                         2,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t8a+adjust);
+    // Informal time.
+    int t8a   = (8 * 3600);
+    int t830a = (8 * 3600) + (30 * 60);
+    int t8p   = (20 * 3600);
+    int t830p = (20 * 3600) + (30 * 60);
+    int t12p  = (12 * 3600);
+    int t1p   = (13 * 3600);
 
-  adjust = (time_now.hour () > 20 || (time_now.hour () == 20 && time_now.minute () > 30)) ? 86400 : 0;
-  testParse (t, "8:30pm",                     6,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830p+adjust);
-  testParse (t, "8:30p",                      5,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t830p+adjust);
+    Datetime time_now;
+    int adjust = (time_now.hour () > 10 || (time_now.hour () == 10 && time_now.minute () > 30)) ? 86400 : 0;
+    testParse (t, "10:30am",                    7,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830a+adjust+(2*3600));
 
-  adjust = (time_now.hour () >= 20) ? 86400 : 0;
-  testParse (t, "8pm",                        3,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t8p+adjust);
-  testParse (t, "8p",                         2,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t8p+adjust);
+    adjust = (time_now.hour () > 8 || (time_now.hour () == 8 && time_now.minute () > 30)) ? 86400 : 0;
+    testParse (t, "8:30am",                     6,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830a+adjust);
+    testParse (t, "8:30a",                      5,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830a+adjust);
+    testParse (t, "8:30",                       4,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830a+adjust);
 
-  adjust = (time_now.hour () >= 12) ? 86400 : 0;
-  testParse (t, "12pm",                       4,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t12p+adjust);
+    adjust = (time_now.hour () >= 8) ? 86400 : 0;
+    testParse (t, "8am",                        3,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t8a+adjust);
+    testParse (t, "8a",                         2,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t8a+adjust);
 
-  adjust = (time_now.hour () >= 13) ? 86400 : 0;
-  testParse (t, "1pm",                        3,    0,  0,  0, 0,   0,  0,     0,     0, false, local+t1p+adjust);
+    adjust = (time_now.hour () > 20 || (time_now.hour () == 20 && time_now.minute () > 30)) ? 86400 : 0;
+    testParse (t, "8:30pm",                     6,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830p+adjust);
+    testParse (t, "8:30p",                      5,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t830p+adjust);
+
+    adjust = (time_now.hour () >= 20) ? 86400 : 0;
+    testParse (t, "8pm",                        3,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t8p+adjust);
+    testParse (t, "8p",                         2,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t8p+adjust);
+
+    adjust = (time_now.hour () >= 12) ? 86400 : 0;
+    testParse (t, "12pm",                       4,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t12p+adjust);
+
+    adjust = (time_now.hour () >= 13) ? 86400 : 0;
+    testParse (t, "1pm",                        3,    0,  0,  0, wks,   0,  0,     0,     0, false, local+t1p+adjust);
+  }
 
   try
   {
@@ -1290,6 +1305,12 @@ int main (int, char**)
     testParseError (t, "12:12+3:20");
     testParseError (t, "12:12+03:2");
     testParseError (t, "12:12+3:2");
+
+    // Test weekday validity under different weekstarts.
+    Datetime::weekstart = 0;
+    testParseError (t, "2024-W01-7");
+    Datetime::weekstart = 1;
+    testParseError (t, "2024-W01-0");
 
     // Test with standlalone date enable/disabled.
     Datetime::standaloneDateEnabled = true;

--- a/test/datetime.t.cpp
+++ b/test/datetime.t.cpp
@@ -693,6 +693,32 @@ int main (int, char**)
     Datetime f_iso (2147483650);
     t.is (f_iso.toISO (), "20380119T031410Z", "2147483650 -> 20380119T031410Z");
 
+    // Test known-overlapped ISO8601 year boundaries, including leap year 1980.
+    // Only makes sense for weekstart == 1 which activates the ISO8601 algorithm.
+    // Dates are taken from the table at https://en.wikipedia.org/wiki/ISO_week_date
+    Datetime::weekstart = 1;
+    //            input         y   m     mo  wk wd jul d sec tz utc    time_t
+    testParse (t, "1976-W53-6", 10, 1976,  0, 53, 6, 0, 0, 0, 0, false, Datetime (1977,  1,  1).toEpoch ());
+    testParse (t, "1976-W53-6", 10, 1976,  0, 53, 6, 0, 0, 0, 0, false, Datetime (1977,  1,  1).toEpoch ());
+    testParse (t, "1976-W53-7", 10, 1976,  0, 53, 7, 0, 0, 0, 0, false, Datetime (1977,  1,  2).toEpoch ());
+    testParse (t, "1977-W52-6", 10, 1977,  0, 52, 6, 0, 0, 0, 0, false, Datetime (1977, 12, 31).toEpoch ());
+    testParse (t, "1977-W52-7", 10, 1977,  0, 52, 7, 0, 0, 0, 0, false, Datetime (1978,  1,  1).toEpoch ());
+    testParse (t, "1978-W01-1", 10, 1978,  0,  1, 1, 0, 0, 0, 0, false, Datetime (1978,  1,  2).toEpoch ());
+    testParse (t, "1978-W52-7", 10, 1978,  0, 52, 7, 0, 0, 0, 0, false, Datetime (1978, 12, 31).toEpoch ());
+    testParse (t, "1979-W01-1", 10, 1979,  0,  1, 1, 0, 0, 0, 0, false, Datetime (1979,  1,  1).toEpoch ());
+    testParse (t, "1979-W52-7", 10, 1979,  0, 52, 7, 0, 0, 0, 0, false, Datetime (1979, 12, 30).toEpoch ());
+    testParse (t, "1980-W01-1", 10, 1980,  0,  1, 1, 0, 0, 0, 0, false, Datetime (1979, 12, 31).toEpoch ());
+    testParse (t, "1980-W01-2", 10, 1980,  0,  1, 2, 0, 0, 0, 0, false, Datetime (1980,  1,  1).toEpoch ());
+    testParse (t, "1980-W52-7", 10, 1980,  0, 52, 7, 0, 0, 0, 0, false, Datetime (1980, 12, 28).toEpoch ());
+    testParse (t, "1981-W01-1", 10, 1981,  0,  1, 1, 0, 0, 0, 0, false, Datetime (1980, 12, 29).toEpoch ());
+    testParse (t, "1981-W01-2", 10, 1981,  0,  1, 2, 0, 0, 0, 0, false, Datetime (1980, 12, 30).toEpoch ());
+    testParse (t, "1981-W01-3", 10, 1981,  0,  1, 3, 0, 0, 0, 0, false, Datetime (1980, 12, 31).toEpoch ());
+    testParse (t, "1981-W01-4", 10, 1981,  0,  1, 4, 0, 0, 0, 0, false, Datetime (1981,  1,  1).toEpoch ());
+    testParse (t, "1981-W53-4", 10, 1981,  0, 53, 4, 0, 0, 0, 0, false, Datetime (1981, 12, 31).toEpoch ());
+    testParse (t, "1981-W53-5", 10, 1981,  0, 53, 5, 0, 0, 0, 0, false, Datetime (1982,  1,  1).toEpoch ());
+    testParse (t, "1981-W53-6", 10, 1981,  0, 53, 6, 0, 0, 0, 0, false, Datetime (1982,  1,  2).toEpoch ());
+    testParse (t, "1981-W53-7", 10, 1981,  0, 53, 7, 0, 0, 0, 0, false, Datetime (1982,  1,  3).toEpoch ());
+
     // Quantization.
     Datetime quant (1234526400);
     t.is (quant.startOfDay ().toString ("YMDHNS"),   "20090213000000", "1234526400 -> 2/13/2009 12:00:00 UTC -> 2/13/2009 0:00:00");


### PR DESCRIPTION
This PR implements the ISO8601 algorithm for `Datetime::weekstart == 1` while retaining existing behavior for `Datetime::weekstart == 0`.

### Existing Behavior

There are some issues with the existing week number parsing:

- Weeks start on Sunday if specified using week numbers like `2024-W31`.
- These weeks do not correspond to e.g. `sow`, `sonw`, which are Monday-based.
- Neither do these weeks correspond to timewarrior hints like `:week`, `:lastweek`.
- The weekdays in such a string (`5` in `2013-W49-5`) use 0-6 Sunday-Monday syntax rather than 1-7 Monday-Sunday as specified in ISO8601
- The week numbers for certain year transitions do not correspond to ISO weeks.
- Value of `Datetime::weekstart` set in libshared does not change any of this, whether set to 0 or 1.

For example `2013-W49` is a frequently tested case in `test/datetime.t.cpp`:

```
 $ task calc 2013-W49
2013-12-01T00:00:00
```

the returned date is a Sunday:
```
 $ cal 12 2013
   December 2013
Su Mo Tu We Th Fr Sa
 1  2  3  4  5  6  7
 8  9 10 11 12 13 14
15 16 17 18 19 20 21
22 23 24 25 26 27 28
29 30 31
```

the calculation is using Sunday-based weeks:
```
 $ ncal -wS 12 2013
    December 2013
Su  1  8 15 22 29
Mo  2  9 16 23 30
Tu  3 10 17 24 31
We  4 11 18 25
Th  5 12 19 26
Fr  6 13 20 27
Sa  7 14 21 28
   49 50 51 52  1

 $ man ncal | grep -- -'[SMw]'
     -w      Print the number of the week below each week column.
     -M      Weeks start on Monday.
     -S      Weeks start on Sunday.
  The week number computed by -w is compliant with the ISO 8601 specification.
```

Timewarrior was parsing weeks as Sunday-based also:
```
 $ timew sum 2024-W30 - 2024-W31 | grep -Pm1 ^W\\d | tr -s $'\x20'
W29 2024-07-21 Sun @99 time/github 3:57:13 4:04:33 0:07:20
```

this despite its `:week` hint starting on Monday:
```
 $ timew sum :week | grep -Pm1 ^W\\d | tr -s $'\x20' | fmt | head -1
W30 2024-07-22 Mon @90 +bug, app/, app/timew/, app/timew/timewisoweekbug
```

Finally, ISO weeks are numbered 1-7 (Monday - Sunday), whereas this library had used 0-6 (Sunday - Monday).  The existing usage is simpler because 0-6 corresponds to the `.tm_wday` field values, however this field is never used as input: `mktime()` uses it only as an output field, recomputed from day/month/year, and libshared is typically using `mktime()` to get a number of seconds, to change into a Julian (ordinal offset from Jan 1) and this is how it will come up with a date (if not directly from `.tm_year`, `.tm_mon`, `tm_mday` as it does in some places).

### New Behavior

ISO8601 defines weeks as starting on Monday, and the first week of the year is the one containing the first Thursday.  Furthermore, all years are to contain an exact integer multiple of weeks.  This means that, for example Jan 1 2023 is actually ISO week 52 in year 2022:
```
 $ ncal -wM 1 2023
January 2023
Mo     2  9 16 23 30
Tu     3 10 17 24 31
We     4 11 18 25
Th     5 12 19 26
Fr     6 13 20 27
Sa     7 14 21 28
Su  1  8 15 22 29
   52  1  2  3  4  5
```

The new code is uses the ISO calculations (only when weekstart is 1):
```
 $ src/calc 2023-W01
2023-01-02T00:00:00

 $ src/calc 2013-W49
2013-12-02T00:00:00
```

The new ISO8601 behavior for `Datetime::weekstart == 1` will be a breaking change for users relying on existing week date parsing.  This is unavoidable for `weekstart == 1`.  However if the user wants `weekstart == 0`, the old behavior is still possible if Taskwarrior/Timewarrior were modified to set `Datetime::weekstart` before libshared calls (which they currently do not).  Taskwarrior could propagate its `rc.weekstart` value (used only for `task calendar` so far) and propagate this value to libshared, for example.

Week numbers will be "off by one" compared to Sunday-based weeks, on the first day of the week, and there are some differences around the year boundary weeks.

### Rationale

Monday-based weeks, and in particular ISO8601 are used broadly in business and finance, commonly in most of the world, and increasingly in the USA as well, although Sunday weeks still remain in colloquial use there.

Since all the existing week shortcut names available to users assume Monday-based weeks (like taskw `sonw` and timew `:lastweek`), this PR is adding consistency, while adhering to the widely accepted standard ISO8601, and leaving a path open for keeping Sunday-based behavior by library users if they set `Datetime::weekstart = 0`.

### Tests

I have updated tests to run all the `testParse()` with both weekstarts (0 or 1), and made sure the code works with both values.

Also added tests for a bunch of dates around year boundaries which differ between ISO and non-ISO interpretations.  These are only tested for when weekstart 1, as the weekstart 0 case is already covered by existing tests and should contain no "surprise" results such as happens with ISO year numbers differing from calendar years in cases when first week does not contain Thursday.

See commit messages for additional information.

Fixes #80
