### PR TITLE
Fix test runs after recent gh/docker/cmake changes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,4 +54,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Test on ${{ matrix.name }}"
-        run: docker-compose up ${{ matrix.container }}
+        run: docker compose up ${{ matrix.container }}

--- a/test/docker/task.dockerfile
+++ b/test/docker/task.dockerfile
@@ -68,7 +68,7 @@ ADD . src/libshared
 
 # Build Taskwarrior
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-RUN cmake --build build -j 8 --target build_tests
+RUN cmake --build build -j 8 --target test_runner --target task_executable
 
 # Running tests
 CMD ctest --test-dir build -j 8 --output-on-failure --rerun-failed


### PR DESCRIPTION
A couple fixes to get the test runner working again:

- Github has retired "docker-compose" (ie v1) and now requires to be invoked as "docker compose".  See url to a discussion in the commit message.
- Also there were some recent changes to Taskwarrior cmake rules whilst making C++ tests run with a single executable, which now requires a trivial change in the docker file.

After these fixes, the tests work again.
