### PR TITLE
Add defines for the values that are allowed for epoch timestamps

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -701,8 +701,8 @@ bool Datetime::parse_epoch (Pig& pig)
   long long epoch {};
   if (pig.getDigits (epoch)             &&
       ! unicodeLatinAlpha (pig.peek ()) &&
-      epoch >= 315532800                &&
-      epoch < 253402293599 )  // 9999-12-31, 23:59:59 AoE
+      epoch >= EPOCH_MIN_VALUE          &&
+      epoch < EPOCH_MAX_VALUE)
   {
     _date = static_cast <time_t> (epoch);
     return true;

--- a/src/Datetime.h
+++ b/src/Datetime.h
@@ -31,6 +31,9 @@
 #include <ctime>
 #include <string>
 
+#define EPOCH_MIN_VALUE 315532800    // 1980-01-01T00:00:00Z
+#define EPOCH_MAX_VALUE 253402293599 // 9999-12-31, 23:59:59 AoE
+
 class Datetime
 {
 public:


### PR DESCRIPTION
Expose them so they can be used in other places.

See https://github.com/GothenburgBitFactory/taskwarrior/pull/3651 for example of usage.