### PR TITLE
Fix week number from Datetime::week() when weekstart=0

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -3654,8 +3654,6 @@ int Datetime::week () const
     throw std::string ("The week may only start on a Sunday or Monday.");
 
   int weekNumber = strtol (weekStr, nullptr, 10);
-  if (weekstart == 0)
-    weekNumber += 1;
 
   return weekNumber;
 }


### PR DESCRIPTION
When working on GothenburgBitFactory/taskwarrior#3623, after modifying the code to pass the user-configured `rc.weekstart` down into `Datetime::weekstart`, it was discovered that the returned week number from `Datetime::week()` was one more than it should be when `weekstart=0` (but not `weekstart=1`).  The code was doing:

```
char weekStr[3];
struct tm* t = localtime (&_date);
strftime (weekStr, sizeof (weekStr), "%U", t);
int weekNumber = strtol (weekStr, NULL, 10);
if (weekstart == 0)
  weekNumber += 1; // <-- HERE
```

This increment was never activated before, because `Datetime::weekstart` was initialized to 1 in the library, and never altered by TW.  Now that it can be set using configuration (in forthcoming patch), there was breakage seen with `weekstart=0` (but not `weekstart=1`).  This was unearthed by TW tests:
```
not ok 20 - dom2.test.py: DOM 3.due.week
# FAIL: AssertionError [...]
#       '35
# ' != '36
# '
#       - 35
#       + 36
```

I followed it in a debugger to the [apparently bogus] increment in `Datetime::week()`.  Example that breaks without the patch:
```
task add testing
task mod 1 due:2011-09-01
task rc.weekstart=monday _get 1.due.week # --> 35 (correct)
task rc.weekstart=sunday _get 1.due.week # --> 36 (incorrect)
```

The week of 2011-09-01 should be 35 regardless of weekstart:
```
 $ env - ncal -w -M 09 2011
    September 2011
Mo     5 12 19 26
Tu     6 13 20 27
We     7 14 21 28
Th  1  8 15 22 29
Fr  2  9 16 23 30
Sa  3 10 17 24
Su  4 11 18 25
   35 36 37 38 39

 $ env - ncal -w -S 09 2011
    September 2011
Su     4 11 18 25
Mo     5 12 19 26
Tu     6 13 20 27
We     7 14 21 28
Th  1  8 15 22 29
Fr  2  9 16 23 30
Sa  3 10 17 24
   35 36 37 38 39

 $ date -d 2011-09-01 +%V
35

 $ date -d 2011-09-01 +%U
35

```