### PR TITLE
feat: add bold color with 256 color space

### DIFF
--- a/test/color.t.cpp
+++ b/test/color.t.cpp
@@ -52,7 +52,7 @@ int main (int, char**)
   t.is ((std::string) c, "color1 on color0", "upgrade color1 on black -> color1 on color0");
 
   c = Color ("bold red on color0");
-  t.is ((std::string) c, "color9 on color0", "upgrade bold red on color0 -> color9 on color0");
+  t.is ((std::string) c, "bold color1 on color0", "upgrade bold red on color0 -> bold color1 on color0");
 
   c = Color ("color1 on bright black");
   t.is ((std::string) c, "color1 on color8", "upgrade color1 on bright black -> color1 on color8");


### PR DESCRIPTION
There is no reason that bold cannot work in 256 color space. Perhaps initially this was disabled due to old terminals not supporting bold and 256 control codes. But in 2024 there is no reason to disable bold.

This PR fixes this and allows users to use bold in themes no matter whether 256 color or 16 color space is used.