### PR TITLE
Add 24bit color support

### DIFF
--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -530,8 +530,8 @@ std::string Color::colorize (const std::string& input) const
 //   256 fg               \033[38;5;Nm
 //   256 bg               \033[48;5;Nm
 //
-//   24 bit fg            \033[38;2;R;G;Bm]
-//   24 bit gg            \033[48;2;R;G;Bm]
+//   24 bit fg            \033[38;2;R;G;Bm
+//   24 bit gg            \033[48;2;R;G;Bm
 void Color::_colorize (std::string &result, const std::string& input) const
 {
   if (!nontrivial ())
@@ -567,11 +567,10 @@ void Color::_colorize (std::string &result, const std::string& input) const
     if (count++) result += ';';
     if (_value & _COLOR_24BIT)
     {
-      result += "\033[38;2;";
+      result += "38;2;";
       result += format((_value >> 16) & 0xFF) + ';';
       result += format((_value >>  8) & 0xFF) + ';';
       result += format((_value)       & 0xFF);
-      result += 'm';
     }
     else if (_value & _COLOR_256)
     {
@@ -589,11 +588,10 @@ void Color::_colorize (std::string &result, const std::string& input) const
     if (count++) result += ';';
     if (_value & _COLOR_24BIT)
     {
-      result += "\033[48;2;";
+      result += "48;2;";
       result += format((_value >> 48) & 0xFF) + ';';
       result += format((_value >> 40) & 0xFF) + ';';
       result += format((_value >> 32) & 0xFF);
-      result += 'm';
     }
     else if (_value & _COLOR_256)
     {

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -29,6 +29,7 @@
 #include <format.h>
 #include <shared.h>
 #include <sstream>
+#include <iomanip>
 
 // uint to string lookup table for Color::_colorize()
 // _colorize() gets called _a lot_, having this lookup table is a cheap
@@ -92,15 +93,26 @@ Color::Color ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-Color::Color (unsigned int c)
+Color::Color (unsigned long int c)
 : _value (0)
 {
-  if (!(c & _COLOR_HASFG)) _value &= ~_COLOR_FG;
-  if (!(c & _COLOR_HASBG)) _value &= ~_COLOR_BG;
+  if ((c & _COLOR_24BIT)) {
+    if (!(c & _COLOR_HASFG)) _value &= ~_COLOR_24BIT_FG;
+    if (!(c & _COLOR_HASBG)) _value &= ~_COLOR_24BIT_BG;
 
-  _value = c & (_COLOR_256 | _COLOR_HASBG | _COLOR_HASFG |_COLOR_UNDERLINE |
-                _COLOR_INVERSE | _COLOR_BOLD | _COLOR_BRIGHT | _COLOR_BG |
-                _COLOR_FG);
+    _value = c & (_COLOR_24BIT | _COLOR_HASBG | _COLOR_HASFG |_COLOR_UNDERLINE |
+                  _COLOR_INVERSE | _COLOR_BOLD | _COLOR_BRIGHT |
+                  _COLOR_24BIT_BG | _COLOR_24BIT_FG);
+  }
+
+  else {
+    if (!(c & _COLOR_HASFG)) _value &= ~_COLOR_FG;
+    if (!(c & _COLOR_HASBG)) _value &= ~_COLOR_BG;
+
+    _value = c & (_COLOR_256 | _COLOR_HASBG | _COLOR_HASFG |_COLOR_UNDERLINE |
+                  _COLOR_INVERSE | _COLOR_BOLD | _COLOR_BRIGHT | _COLOR_BG |
+                  _COLOR_FG);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,10 +123,11 @@ Color::Color (unsigned int c)
 //   black
 //   red
 //   ...
-//   grayN  0 <= N <= 23       fg 38;5;232 + N              bg 48;5;232 + N
-//   greyN  0 <= N <= 23       fg 38;5;232 + N              bg 48;5;232 + N
-//   colorN 0 <= N <= 255      fg 38;5;N                    bg 48;5;N
-//   rgbRGB 0 <= R,G,B <= 5    fg 38;5;16 + R*36 + G*6 + B  bg 48;5;16 + R*36 + G*6 + B
+//   grayN    0 <= N <= 23     fg 38;5;232 + N              bg 48;5;232 + N
+//   greyN    0 <= N <= 23     fg 38;5;232 + N              bg 48;5;232 + N
+//   colorN   0 <= N <= 255    fg 38;5;N                    bg 48;5;N
+//   rgbRGB   0 <= R,G,B <= 5  fg 38;5;16 + R*36 + G*6 + B  bg 48;5;16 + R*36 + G*6 + B
+//   0xRRGGBB 0 <= R,G,B <= FF fg 38;2;R;G;B                bg 48;2;R;G;B
 Color::Color (const std::string& spec)
 : _value (0)
 {
@@ -124,8 +137,8 @@ Color::Color (const std::string& spec)
   // Construct the color as two separate colors, then blend them later.  This
   // make it possible to declare a color such as "color1 on black", and have
   // the upgrade work properly.
-  unsigned int fg_value = 0;
-  unsigned int bg_value = 0;
+  unsigned long int fg_value = 0;
+  unsigned long int bg_value = 0;
 
   bool bg = false;
   int index;
@@ -233,6 +246,28 @@ Color::Color (const std::string& spec)
         fg_value |= _COLOR_256;
       }
     }
+
+    // 0xX where 0 <= X <= 0xFFFFFF.
+    else if (! word.compare (0, 2, "0x", 2))
+    {
+      unsigned long int color = strtol (word.c_str (), nullptr, 16);
+      if (color > 0x00FFFFFF)
+        throw format ("The color '{1}' is not recognized.", word);
+
+      upgrade24b ();
+
+      if (bg) {
+        bg_value |= _COLOR_HASBG;
+        bg_value |= color << 32;
+        bg_value |= _COLOR_24BIT;
+      }
+      else
+      {
+        fg_value |= _COLOR_HASFG;
+        fg_value |= color;
+        fg_value |= _COLOR_24BIT;
+      }
+    }
     else if (!word.empty ())
       throw format ("The color '{1}' is not recognized.", word);
   }
@@ -257,9 +292,9 @@ Color::Color (color_id fg)
 Color::Color (color_id fg, color_id bg, bool underline, bool bold, bool bright)
 : _value (0)
 {
-  _value |= ((underline ? 1 : 0) << 18)
-         |  ((bold      ? 1 : 0) << 17)
-         |  ((bright    ? 1 : 0) << 16);
+  _value |= ((underline ? _COLOR_UNDERLINE : 0))
+         |  ((bold      ? _COLOR_BOLD : 0))
+         |  ((bright    ? _COLOR_BRIGHT : 0));
 
   if (bg != Color::nocolor)
   {
@@ -327,9 +362,31 @@ void Color::blend (const Color& other)
   _value |= (c._value & _COLOR_INVERSE);      // Always inherit inverse.
   _value |= (c._value & _COLOR_BOLD);         // Always inherit bold.
 
+  // 24 bit <-- 24 bit.
+  if ((_value   & _COLOR_24BIT) ||
+      (c._value & _COLOR_24BIT))
+  {
+    // Upgrade either color, if necessary.
+    if (!(_value   & _COLOR_24BIT)) upgrade24b ();
+    if (!(c._value & _COLOR_24BIT)) c.upgrade24b ();
+
+    if (c._value & _COLOR_HASFG)
+    {
+      _value |= _COLOR_HASFG;                  // There is now a color.
+      _value &= ~_COLOR_24BIT_FG;              // Remove previous color.
+      _value |= (c._value & _COLOR_24BIT_FG);  // Apply other color.
+    }
+
+    if (c._value & _COLOR_HASBG)
+    {
+      _value |= _COLOR_HASBG;                  // There is now a color.
+      _value &= ~_COLOR_24BIT_BG;              // Remove previous color.
+      _value |= (c._value & _COLOR_24BIT_BG);  // Apply other color.
+    }
+  }
   // 16 <-- 16.
-  if (!(_value   & _COLOR_256) &&
-      !(c._value & _COLOR_256))
+  else if (!(_value   & _COLOR_256) &&
+           !(c._value & _COLOR_256))
   {
     _value |= (c._value & _COLOR_BRIGHT);     // Inherit bright.
 
@@ -346,8 +403,6 @@ void Color::blend (const Color& other)
       _value &= ~_COLOR_BG;                   // Remove previous color.
       _value |= (c._value & _COLOR_BG);       // Apply other color.
     }
-
-    return;
   }
   else
   {
@@ -375,26 +430,83 @@ void Color::blend (const Color& other)
 ////////////////////////////////////////////////////////////////////////////////
 void Color::upgrade ()
 {
-  if (!(_value & _COLOR_256))
+  if ((_value & _COLOR_256) ||
+      (_value & _COLOR_24BIT)) return;
+
+  if (_value & _COLOR_HASFG)
   {
-    if (_value & _COLOR_HASFG)
-    {
-      unsigned int fg = _value & _COLOR_FG;
-      _value &= ~_COLOR_FG;
-      _value |= fg - 1;
-    }
-
-    if (_value & _COLOR_HASBG)
-    {
-      bool bright = _value & _COLOR_BRIGHT;
-      unsigned int bg = (_value & _COLOR_BG) >> 8;
-      _value &= ~_COLOR_BG;
-      _value &= ~_COLOR_BRIGHT;
-      _value |= (bright ? bg + 7 : bg - 1) << 8;
-    }
-
-    _value |= _COLOR_256;
+    unsigned int fg = _value & _COLOR_FG;
+    _value &= ~_COLOR_FG;
+    _value |= fg - 1;
   }
+
+  if (_value & _COLOR_HASBG)
+  {
+    bool bright = _value & _COLOR_BRIGHT;
+    unsigned int bg = (_value & _COLOR_BG) >> 8;
+    _value &= ~_COLOR_BG;
+    _value &= ~_COLOR_BRIGHT;
+    _value |= (bright ? bg + 7 : bg - 1) << 8;
+  }
+
+  _value |= _COLOR_256;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void Color::upgrade24b ()
+{
+  if (_value & _COLOR_24BIT) return;
+
+  upgrade ();
+
+  _value &= ~_COLOR_256;
+
+  if (_value & _COLOR_HASFG)
+  {
+    unsigned int fg = _value & _COLOR_FG;
+    _value &= ~_COLOR_FG;
+    _value |= index2truecolor(fg);
+  }
+
+  if (_value & _COLOR_HASBG)
+  {
+    unsigned int bg = (_value & _COLOR_BG) >> 8;
+    _value &= ~_COLOR_FG;
+    _value |= ((unsigned long int)(index2truecolor(bg)) << 32);
+  }
+
+  _value |= _COLOR_24BIT;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+unsigned int Color::index2truecolor(unsigned int index) {
+  unsigned int color = 0x0;
+
+  if (index <= 8)
+  {
+    color |= (index & 1) * 0x800000;
+    color |= (index & 2) * 0x004000;
+    color |= (index & 4) * 0x000020;
+  }
+  else if (index <= 16)
+  {
+    color |= (index        & 1) * 0xFF0000;
+    color |= ((index >> 1) & 1) * 0x00FF00;
+    color |= ((index >> 2) & 1) * 0x0000FF;
+  }
+  else if (index <= 231)
+  {
+    index -= 16;
+    color |= ((index / 36)    ) * 0x2a0000;
+    color |= ((index % 36) / 6) * 0x002a00;
+    color |= ((index %  6)    ) * 0x00002a;
+  }
+  else
+  {
+    color |= (index - 231) * 0x0a0a0a;
+  }
+
+  return color;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -417,6 +529,9 @@ std::string Color::colorize (const std::string& input) const
 //
 //   256 fg               \033[38;5;Nm
 //   256 bg               \033[48;5;Nm
+//
+//   24 bit fg            \033[38;2;R;G;Bm]
+//   24 bit gg            \033[48;2;R;G;Bm]
 void Color::_colorize (std::string &result, const std::string& input) const
 {
   if (!nontrivial ())
@@ -450,7 +565,15 @@ void Color::_colorize (std::string &result, const std::string& input) const
   if (_value & _COLOR_HASFG)
   {
     if (count++) result += ';';
-    if (_value & _COLOR_256)
+    if (_value & _COLOR_24BIT)
+    {
+      result += "\033[38;2;";
+      result += format((_value >> 16) & 0xFF) + ';';
+      result += format((_value >>  8) & 0xFF) + ';';
+      result += format((_value)       & 0xFF);
+      result += 'm';
+    }
+    else if (_value & _COLOR_256)
     {
       result += "38;5;";
       result += colorstring[(_value & _COLOR_FG)];
@@ -464,7 +587,15 @@ void Color::_colorize (std::string &result, const std::string& input) const
   if (_value & _COLOR_HASBG)
   {
     if (count++) result += ';';
-    if (_value & _COLOR_256)
+    if (_value & _COLOR_24BIT)
+    {
+      result += "\033[48;2;";
+      result += format((_value >> 48) & 0xFF) + ';';
+      result += format((_value >> 40) & 0xFF) + ';';
+      result += format((_value >> 32) & 0xFF);
+      result += 'm';
+    }
+    else if (_value & _COLOR_256)
     {
       result += "48;5;";
       result += colorstring[((_value & _COLOR_BG) >> 8)];
@@ -521,8 +652,36 @@ std::string Color::code () const
 
   std::string result;
 
+  // 24 bit color
+  if (_value & _COLOR_24BIT)
+  {
+    if (_value & _COLOR_UNDERLINE)
+      result += "\033[4m";
+
+    if (_value & _COLOR_INVERSE)
+      result += "\033[7m";
+
+    if (_value & _COLOR_HASFG)
+    {
+      result += "\033[38;2;";
+      result += format((_value >> 16) & 0xFF) + ';';
+      result += format((_value >>  8) & 0xFF) + ';';
+      result += format((_value)       & 0xFF);
+      result += 'm';
+    }
+
+    if (_value & _COLOR_HASBG)
+    {
+      result += "\033[48;2;";
+      result += format((_value >> 48) & 0xFF) + ';';
+      result += format((_value >> 40) & 0xFF) + ';';
+      result += format((_value >> 32) & 0xFF);
+      result += 'm';
+    }
+  }
+
   // 256 color
-  if (_value & _COLOR_256)
+  else if (_value & _COLOR_256)
   {
     if (_value & _COLOR_UNDERLINE)
       result += "\033[4m";
@@ -615,9 +774,17 @@ int Color::find (const std::string& input)
 ////////////////////////////////////////////////////////////////////////////////
 std::string Color::fg () const
 {
-  int index = _value & _COLOR_FG;
-
-  if (_value & _COLOR_256)
+  if (_value & _COLOR_24BIT)
+  {
+    if (_value & _COLOR_HASFG)
+    {
+      std::stringstream s;
+      s << "0x" << std::setfill('0') << std::setw(6) << std::hex <<
+        (_value & _COLOR_24BIT_FG);
+      return s.str ();
+    }
+  }
+  else if (_value & _COLOR_256)
   {
     if (_value & _COLOR_HASFG)
     {
@@ -628,6 +795,7 @@ std::string Color::fg () const
   }
   else
   {
+    int index = _value & _COLOR_FG;
     for (unsigned int i = 0; i < NUM_COLORS; ++i)
       if (allColors[i].index == index)
         return allColors[i].english_name;
@@ -639,9 +807,17 @@ std::string Color::fg () const
 ////////////////////////////////////////////////////////////////////////////////
 std::string Color::bg () const
 {
-  int index = (_value & _COLOR_BG) >> 8;
-
-  if (_value & _COLOR_256)
+  if (_value & _COLOR_24BIT)
+  {
+    if (_value & _COLOR_HASBG)
+    {
+      std::stringstream s;
+      s << "0x" << std::setfill('0') << std::setw(6) << std::hex <<
+        ((_value & _COLOR_24BIT_BG) >> 32);
+      return s.str ();
+    }
+  }
+  else if (_value & _COLOR_256)
   {
     if (_value & _COLOR_HASBG)
     {
@@ -652,6 +828,7 @@ std::string Color::bg () const
   }
   else
   {
+    int index = (_value & _COLOR_BG) >> 8;
     for (unsigned int i = 0; i < NUM_COLORS; ++i)
       if (allColors[i].index == index)
         return allColors[i].english_name;

--- a/src/Color.h
+++ b/src/Color.h
@@ -29,15 +29,18 @@
 
 #include <string>
 
-#define _COLOR_INVERSE   0x00400000  // Inverse attribute.
-#define _COLOR_256       0x00200000  // 256-color mode.
-#define _COLOR_HASBG     0x00100000  // Has background color (all values taken).
-#define _COLOR_HASFG     0x00080000  // Has foreground color (all values taken).
-#define _COLOR_UNDERLINE 0x00040000  // General underline attribute.
-#define _COLOR_BOLD      0x00020000  // 16-color bold attribute.
-#define _COLOR_BRIGHT    0x00010000  // 16-color bright background attribute.
-#define _COLOR_BG        0x0000FF00  // 8-bit background color index.
-#define _COLOR_FG        0x000000FF  // 8-bit foreground color index.
+#define _COLOR_24BIT     0x0000000080000000  // 24-bit mode.
+#define _COLOR_INVERSE   0x0000000040000000  // Inverse attribute.
+#define _COLOR_256       0x0000000020000000  // 256-color mode.
+#define _COLOR_HASBG     0x0000000010000000  // Has background color (all values taken).
+#define _COLOR_HASFG     0x0000000008000000  // Has foreground color (all values taken).
+#define _COLOR_UNDERLINE 0x0000000004000000  // General underline attribute.
+#define _COLOR_BOLD      0x0000000002000000  // 16-color bold attribute.
+#define _COLOR_BRIGHT    0x0000000001000000  // 16-color bright background attribute.
+#define _COLOR_BG        0x000000000000FF00  // 8-bit background color index.
+#define _COLOR_FG        0x00000000000000FF  // 8-bit foreground color index.
+#define _COLOR_24BIT_BG  0x00FFFFFF00000000  // 24-bit background color index.
+#define _COLOR_24BIT_FG  0x0000000000FFFFFF  // 24-bit foreground color index.
 
 class Color
 {
@@ -47,7 +50,7 @@ public:
   Color ();
   Color (const Color&) = default;
   Color& operator= (const Color&) = default;
-  Color (unsigned int);                         // 256 | INVERSE | UNDERLINE | BOLD | BRIGHT | (BG << 8) | FG
+  Color (unsigned long int);                    // 256 | INVERSE | UNDERLINE | BOLD | BRIGHT | (BG << 8) | FG
   Color (const std::string&);                   // "red on bright black"
   Color (color_id);                             // fg.
   Color (color_id, color_id, bool, bool, bool); // fg, bg, underline, bold, bright
@@ -55,6 +58,8 @@ public:
   operator int () const;
 
   void upgrade ();
+  void upgrade24b ();
+  unsigned int index2truecolor(unsigned int);
   void blend (const Color&);
 
   std::string colorize (const std::string&) const;
@@ -74,7 +79,7 @@ private:
   std::string bg () const;
 
 private:
-  unsigned int _value;
+  unsigned long int _value;
 };
 
 #endif

--- a/test/color.t.cpp
+++ b/test/color.t.cpp
@@ -189,13 +189,13 @@ int main (int, char**)
 
 
   // 24-bit color
-  t.is (Color::colorize ("foo", "0x0a1b2c"),               std::string ("\033[38;2;10;27;44mfoo\033[0m"),                       "0x0a1b2c               -> ^[[38;2;10;27;44m");
-  t.is (Color::colorize ("foo", "0x0a1b2c on color127"),   std::string ("\033[38;2;10;27;44m\033[48;2;126;0;126mfoo\033[0m"),   "0x0a1b2c on color127   -> ^[[38;2;10;27;44m^[[48;2;126;0;126m");
-  t.is (Color::colorize ("foo", "red on 0x0a1b2c"),        std::string ("\033[38;2;128;0;0m\033[48;2;10;27;44mfoo\033[0m"),     "red on 0x0a1b2c        -> ^[[38;2;128;0;0m^[[38;2;10;27;44m");
-  t.is (Color::colorize ("foo", "bold red on 0x0a1b2c"),   std::string ("\033[38;2;255;0;0m\033[48;2;10;27;44mfoo\033[0m"),     "bold on 0x0a1b2c       -> ^[[38;2;255;0;0m^[[38;2;10;27;44m");
-  t.is (Color::colorize ("foo", "0x0a1b2c on bright red"), std::string ("\033[38;2;10;27;44m\033[48;2;255;0;0mfoo\033[0m"),     "0x0a1b2c on bright red -> ^[[38;2;10;27;44m^[[48;2;255;0;0m");
-  t.is (Color::colorize ("foo", "0x010101 on grey0"),      std::string ("\033[38;2;1;1;1m\033[48;2;10;10;10mfoo\033[0m"),       "0x0101010 on grey0     -> ^[[38;2;1;1;1m^[[48;2;10;10;10m");
-  t.is (Color::colorize ("foo", "0x101010 on grey23"),     std::string ("\033[38;2;16;16;16m\033[48;2;240;240;240mfoo\033[0m"), "0x101010 on grey0      -> ^[[38;2;16;16;16m^[[48;2;240;240;240m");
+  t.is (Color::colorize ("foo", "0x0a1b2c"),               std::string ("\033[38;2;10;27;44mfoo\033[0m"),                  "0x0a1b2c               -> ^[[38;2;10;27;44m");
+  t.is (Color::colorize ("foo", "0x0a1b2c on color127"),   std::string ("\033[38;2;10;27;44;48;2;126;0;126mfoo\033[0m"),   "0x0a1b2c on color127   -> ^[[38;2;10;27;44;48;2;126;0;126m");
+  t.is (Color::colorize ("foo", "red on 0x0a1b2c"),        std::string ("\033[38;2;128;0;0;48;2;10;27;44mfoo\033[0m"),     "red on 0x0a1b2c        -> ^[[38;2;128;0;0;48;2;10;27;44m");
+  t.is (Color::colorize ("foo", "bold red on 0x0a1b2c"),   std::string ("\033[1;38;2;128;0;0;48;2;10;27;44mfoo\033[0m"),   "bold on 0x0a1b2c       -> ^[[1;38;2;255;0;0;48;2;10;27;44m");
+  t.is (Color::colorize ("foo", "0x0a1b2c on bright red"), std::string ("\033[38;2;10;27;44;48;2;255;0;0mfoo\033[0m"),     "0x0a1b2c on bright red -> ^[[38;2;10;27;44;48;2;255;0;0m");
+  t.is (Color::colorize ("foo", "0x010101 on grey0"),      std::string ("\033[38;2;1;1;1;48;2;10;10;10mfoo\033[0m"),       "0x0101010 on grey0     -> ^[[38;2;1;1;1;48;2;10;10;10m");
+  t.is (Color::colorize ("foo", "0x101010 on grey23"),     std::string ("\033[38;2;16;16;16;48;2;240;240;240mfoo\033[0m"), "0x101010 on grey0      -> ^[[38;2;16;16;16;48;2;240;240;240m");
 
 
   t.is (Color ("0x0F1E2D").code (), "[38;2;15;30;45m", "Color::code '0x0F1E2D' --> ^[[38;2;15;30;45m");

--- a/test/color.t.cpp
+++ b/test/color.t.cpp
@@ -187,6 +187,19 @@ int main (int, char**)
   // std::string Color::code () const;
   t.is (Color ("rgb012 on bright yellow").code (), "[38;5;24m[48;5;11m", "Color::code 'rgb0123 on bright yellow' --> ^[[38;5;24m^[[48;5;11m");
 
+
+  // 24-bit color
+  t.is (Color::colorize ("foo", "0x0a1b2c"),               std::string ("\033[38;2;10;27;44mfoo\033[0m"),                       "0x0a1b2c               -> ^[[38;2;10;27;44m");
+  t.is (Color::colorize ("foo", "0x0a1b2c on color127"),   std::string ("\033[38;2;10;27;44m\033[48;2;126;0;126mfoo\033[0m"),   "0x0a1b2c on color127   -> ^[[38;2;10;27;44m^[[48;2;126;0;126m");
+  t.is (Color::colorize ("foo", "red on 0x0a1b2c"),        std::string ("\033[38;2;128;0;0m\033[48;2;10;27;44mfoo\033[0m"),     "red on 0x0a1b2c        -> ^[[38;2;128;0;0m^[[38;2;10;27;44m");
+  t.is (Color::colorize ("foo", "bold red on 0x0a1b2c"),   std::string ("\033[38;2;255;0;0m\033[48;2;10;27;44mfoo\033[0m"),     "bold on 0x0a1b2c       -> ^[[38;2;255;0;0m^[[38;2;10;27;44m");
+  t.is (Color::colorize ("foo", "0x0a1b2c on bright red"), std::string ("\033[38;2;10;27;44m\033[48;2;255;0;0mfoo\033[0m"),     "0x0a1b2c on bright red -> ^[[38;2;10;27;44m^[[48;2;255;0;0m");
+  t.is (Color::colorize ("foo", "0x010101 on grey0"),      std::string ("\033[38;2;1;1;1m\033[48;2;10;10;10mfoo\033[0m"),       "0x0101010 on grey0     -> ^[[38;2;1;1;1m^[[48;2;10;10;10m");
+  t.is (Color::colorize ("foo", "0x101010 on grey23"),     std::string ("\033[38;2;16;16;16m\033[48;2;240;240;240mfoo\033[0m"), "0x101010 on grey0      -> ^[[38;2;16;16;16m^[[48;2;240;240;240m");
+
+
+  t.is (Color ("0x0F1E2D").code (), "[38;2;15;30;45m", "Color::code '0x0F1E2D' --> ^[[38;2;15;30;45m");
+
   // std::string Color::end () const;
   t.is (Color ("red").end (), "[0m", "Color::end --> ^[[0m");
 

--- a/test/color.t.cpp
+++ b/test/color.t.cpp
@@ -31,7 +31,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 int main (int, char**)
 {
-  UnitTest t (40 + 256 + 256 + 6*6*6 + 6*6*6 + 1 + 24 + 24 + 5);
+  UnitTest t (40 + 256 + 256 + 6*6*6 + 6*6*6 + 1 + 24 + 24 + 7 + 6);
 
   // Names matched to values.
   t.is ((int) Color (""),        (int) Color (Color::nocolor), "''        == Color::nocolor");
@@ -179,15 +179,6 @@ int main (int, char**)
     t.is (Color::colorize ("foo", color), std::string (codes), description);
   }
 
-  // std::string Color::strip (const std::string&);
-  t.is (Color::strip (""),                  "",    "Color::strip '' -> ''");
-  t.is (Color::strip ("foo"),               "foo", "Color::strip 'foo' -> 'foo'");
-  t.is (Color::strip ("f\033[1mo\033[0mo"), "foo", "Color::strip 'f<b>o</b>o' -> 'foo'");
-
-  // std::string Color::code () const;
-  t.is (Color ("rgb012 on bright yellow").code (), "[38;5;24m[48;5;11m", "Color::code 'rgb0123 on bright yellow' --> ^[[38;5;24m^[[48;5;11m");
-
-
   // 24-bit color
   t.is (Color::colorize ("foo", "0x0a1b2c"),               std::string ("\033[38;2;10;27;44mfoo\033[0m"),                  "0x0a1b2c               -> ^[[38;2;10;27;44m");
   t.is (Color::colorize ("foo", "0x0a1b2c on color127"),   std::string ("\033[38;2;10;27;44;48;2;126;0;126mfoo\033[0m"),   "0x0a1b2c on color127   -> ^[[38;2;10;27;44;48;2;126;0;126m");
@@ -195,9 +186,15 @@ int main (int, char**)
   t.is (Color::colorize ("foo", "bold red on 0x0a1b2c"),   std::string ("\033[1;38;2;128;0;0;48;2;10;27;44mfoo\033[0m"),   "bold on 0x0a1b2c       -> ^[[1;38;2;255;0;0;48;2;10;27;44m");
   t.is (Color::colorize ("foo", "0x0a1b2c on bright red"), std::string ("\033[38;2;10;27;44;48;2;255;0;0mfoo\033[0m"),     "0x0a1b2c on bright red -> ^[[38;2;10;27;44;48;2;255;0;0m");
   t.is (Color::colorize ("foo", "0x010101 on grey0"),      std::string ("\033[38;2;1;1;1;48;2;10;10;10mfoo\033[0m"),       "0x0101010 on grey0     -> ^[[38;2;1;1;1;48;2;10;10;10m");
-  t.is (Color::colorize ("foo", "0x101010 on grey23"),     std::string ("\033[38;2;16;16;16;48;2;240;240;240mfoo\033[0m"), "0x101010 on grey0      -> ^[[38;2;16;16;16;48;2;240;240;240m");
+  t.is (Color::colorize ("foo", "0x101010 on grey23"),     std::string ("\033[38;2;16;16;16;48;2;240;240;240mfoo\033[0m"), "0x101010 on grey23     -> ^[[38;2;16;16;16;48;2;240;240;240m");
 
+  // std::string Color::strip (const std::string&);
+  t.is (Color::strip (""),                  "",    "Color::strip '' -> ''");
+  t.is (Color::strip ("foo"),               "foo", "Color::strip 'foo' -> 'foo'");
+  t.is (Color::strip ("f\033[1mo\033[0mo"), "foo", "Color::strip 'f<b>o</b>o' -> 'foo'");
 
+  // std::string Color::code () const;
+  t.is (Color ("rgb012 on bright yellow").code (), "[38;5;24m[48;5;11m", "Color::code 'rgb0123 on bright yellow' --> ^[[38;5;24m^[[48;5;11m");
   t.is (Color ("0x0F1E2D").code (), "[38;2;15;30;45m", "Color::code '0x0F1E2D' --> ^[[38;2;15;30;45m");
 
   // std::string Color::end () const;


### PR DESCRIPTION
Here's a suggestion for 24-bit color ("truecolor") support:
* Keep the original structure of stuffing all color information into a single integer.
* But use a 64 bit int instead.
* If 24-bit color: store the background color in the upper half.

resolves #3 