### PR TITLE
Remove 'macOS 12' GitHub runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,8 +18,6 @@ jobs:
             runner: ubuntu-22.04
           - name: "macOS 14"
             runner: macos-14
-          - name: "macOS 12"
-            runner: macos-12
           - name: "macOS 13"
             runner: macos-13
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
GitHub is removing the `macOS 12` runner image by 2024-12-03
See https://github.com/actions/runner-images/issues/10721