### PR TITLE
Use 64-bit delta for Datetime +/- operators

### DIFF
--- a/src/Datetime.cpp
+++ b/src/Datetime.cpp
@@ -3788,26 +3788,26 @@ bool Datetime::sameYear (const Datetime& rhs) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-Datetime Datetime::operator+ (const int delta)
+Datetime Datetime::operator+ (const int64_t delta)
 {
   return { _date + delta };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-Datetime Datetime::operator- (const int delta)
+Datetime Datetime::operator- (const int64_t delta)
 {
   return { _date - delta };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-Datetime& Datetime::operator+= (const int delta)
+Datetime& Datetime::operator+= (const int64_t delta)
 {
   _date += (time_t) delta;
   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-Datetime& Datetime::operator-= (const int delta)
+Datetime& Datetime::operator-= (const int64_t delta)
 {
   _date -= (time_t) delta;
   return *this;

--- a/src/Datetime.h
+++ b/src/Datetime.h
@@ -29,6 +29,7 @@
 
 #include <Pig.h>
 #include <ctime>
+#include <cstdint>
 #include <string>
 
 #define EPOCH_MIN_VALUE 315532800    // 1980-01-01T00:00:00Z
@@ -101,10 +102,10 @@ public:
   bool sameMonth   (const Datetime&) const;
   bool sameQuarter (const Datetime&) const;
   bool sameYear    (const Datetime&) const;
-  Datetime operator+  (const int);
-  Datetime operator-  (const int);
-  Datetime& operator+= (const int);
-  Datetime& operator-= (const int);
+  Datetime operator+  (const int64_t);
+  Datetime operator-  (const int64_t);
+  Datetime& operator+= (const int64_t);
+  Datetime& operator-= (const int64_t);
   time_t operator- (const Datetime&);
   void operator--  ();    // Prefix
   void operator--  (int); // Postfix


### PR DESCRIPTION
This allows larger deltas, as `int` is only 32 bits. Even on platforms where time_t is 32 bits, using `int64_t` is not worse than using `int`.