### PR TITLE
extractLine: Handle embedded NULs correctly

### DIFF
--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -73,8 +73,15 @@ unsigned int utf8_codepoint (const std::string& input)
 //   - returns the next character
 unsigned int utf8_next_char (const std::string& input, std::string::size_type& i)
 {
-  if (input[i] == '\0')
+  // Try to recognize end of string without checking length on every call.
+  if (input[i] == '\0') {
+    // If this is not the end of the string, then this is a NUL character
+    // embedded in the string, so advance over it.
+    if (i != input.length()) {
+      i += 1;
+    }
     return 0;
+  }
 
   // How many bytes in the sequence?
   int length = utf8_sequence (input[i]);

--- a/test/shared.t.cpp
+++ b/test/shared.t.cpp
@@ -30,7 +30,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 int main (int, char**)
 {
-  UnitTest t (204);
+  UnitTest t (211);
 
   // void wrapText (std::vector <std::string>& lines, const std::string& text, const int width, bool hyphenate)
   std::string text = "This is a test of the line wrapping code.";
@@ -97,6 +97,19 @@ int main (int, char**)
   extractLine (line, text, 10, true, offset);
   t.is (line, "AAAAAAAAA-", "extractLine hyphenated unbreakable line");
   t.diag (line);
+
+  text = "abc\n";
+  offset = 3;
+  t.ok (extractLine(line, text, 10, true, offset), "extractLine succeeds at trailing newline");
+  t.is (line, "", "recognized newline as a line ending");
+  t.is (offset, 4, "incremented offset");
+
+  text = std::string("abc\0", 4);
+  offset = 3;
+  t.is (text.length(), (size_t)4, "trailing NUL included in string length");
+  t.ok (extractLine(line, text, 10, true, offset), "extractLine succeeds at NUL");
+  t.is (line, "", "recognized NUL as a line ending");
+  t.is (offset, 4, "incremented ofset");
 
 /*
   TODO Resolve above against below, from Taskwarrior 2.6.0


### PR DESCRIPTION
Values in a `std::string` can contain NUL characters, and these should not necessarily indicate the end of the string.

Fixes #93.