### PR TITLE
Handle `\` at end of string in JSON::decode.

### DIFF
--- a/src/JSON.cpp
+++ b/src/JSON.cpp
@@ -466,6 +466,11 @@ std::string json::decode (const std::string& input)
           pos += 3;
           break;
 
+        // End-of-string will always have a NUL in C++11.
+        case 0:
+          output += '\\';
+          break;
+
         // If it is an unrecognized sequence, do nothing.
         default:
           output += '\\';

--- a/test/json.t.cpp
+++ b/test/json.t.cpp
@@ -137,7 +137,7 @@ void saxTest (UnitTest& t, const std::string& input, const std::string& expected
 ////////////////////////////////////////////////////////////////////////////////
 int main (int, char**)
 {
-  UnitTest t (NUM_POSITIVE_TESTS + NUM_NEGATIVE_TESTS + 28 + 4);
+  UnitTest t (NUM_POSITIVE_TESTS + NUM_NEGATIVE_TESTS + 31 + 4);
 
   // Ensure environment has no influence.
   unsetenv ("TASKDATA");
@@ -220,6 +220,15 @@ int main (int, char**)
     t.is (encoded[4], '\\',                  "json::encode one<backslash>[4] -> <backslash>");
 
     t.is (json::decode (encoded), "one\\",   "json::decode one<backslash><backslash> -> one<backslash>");
+
+    // Invalid input, trailing `\`.
+    t.is (json::decode ("1\\"), "1\\", "json::decode <backslash> -> <backslash>");
+
+    // Embedded NUL.
+    t.is (json::decode ("\0012"), "\0012", "json::decode <nul>12 -> <nul>12");
+
+    // Escaped embedded NUL.
+    t.is (json::decode ("\\\0012"), "\\\0012", "json::decode <backslash><nul>12 -> <backslash><nul>12");
   }
 
   catch (const std::string& e) {t.diag (e);}


### PR DESCRIPTION
This fixes a bug where such an input produced a string with a spurious trailing NUL character. This also adds tests for embedded NULs, but those already passed. Fixes #95.