### PR TITLE
Fix Datetime.{h,cpp} to include cmake.h for HAVE_TIMEGM define

### DIFF
--- a/src/Datetime.h
+++ b/src/Datetime.h
@@ -32,6 +32,8 @@
 #include <cstdint>
 #include <string>
 
+#include "cmake.h"
+
 #define EPOCH_MIN_VALUE 315532800    // 1980-01-01T00:00:00Z
 #define EPOCH_MAX_VALUE 253402293599 // 9999-12-31, 23:59:59 AoE
 


### PR DESCRIPTION
The previous move of `Datetime::timegm()` into libshared (from Taskwarrior) in PR #99 caused a significant performance regression in Timewarrior because a slow fallback method was used due to `-DHAVE_TIMEGM` not being picked up from cmake.

That fallback calls `tzset()` for every `timegm()` call, which is done twice for every interval in the Timewarrior data, and involves file I/O with `/etc/localtime`.  These calls can number in the tens of thousands even for simple operations, depending on time db size.

This patch includes `cmake.h` so the `HAVE_TIMEGM` define can be picked up and we'll defer to the libc implementation of `timegm()`, which is much faster (it does not do `tzset()`).

Windows may still be affected by the slowness, it may not have `timegm()`, but it will continue to work there, and should use the faster libc on BSDs and GNU systems.

Problem described more in GothenburgBitFactory/timewarrior#703 and in #104.

Taskwarrior does not seem to use `timegm()`, so no need to bump its libshared.

Fixes #104.
