### PR TITLE
Fix: PUA/Nerd Font character width

### DIFF
--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -341,6 +341,10 @@ int mk_wcwidth(wchar_t ucs)
     if (width == widechar_ambiguous)
       return 1;
 
+    // Interpret Private Use Area (PUA) characters as 1 char for Nerd Fonts
+    if (width == widechar_private_use)
+      return 1;
+
     // Emoji pictographs (U+1F300+) — width 2 in modern terminals
     if ((ucs >= 0x1F300 && ucs <= 0x1F9FF) ||  // Misc Symbols, Pictographs, Emoticons, Supplemental
         (ucs >= 0x1FA00 && ucs <= 0x1FAFF))    // Symbols and Pictographs Extended-A

--- a/test/utf8.t.cpp
+++ b/test/utf8.t.cpp
@@ -152,6 +152,11 @@ int main (int, char**)
   t.is (mk_wcwidth (0x1F602),                           2, "mk_wcwidth U+1F602 '😂' --> 2");
   t.is (mk_wcwidth (0x1F64F),                           2, "mk_wcwidth U+1F64F '🙏' --> 2");
 
+  // Nerd Fonts
+  t.is (mk_wcwidth (0xF023),                           1, "mk_wcwidth U+F023'' --> 1");
+  t.is (mk_wcwidth (0xF023),                           1, "mk_wcwidth U+F023'' --> 1");
+  t.is (mk_wcwidth (0xF023),                           1, "mk_wcwidth U+F023'' --> 1");
+
   t.is (mk_wcwidth (0x5149),                            2, "mk_wcwidth U+5149 --> 2");
   t.is (mk_wcwidth (0x9a8c),                            2, "mk_wcwidth U+9a8c --> 2");
   t.is (mk_wcwidth (0x4e70),                            2, "mk_wcwidth U+4e70 --> 2");


### PR DESCRIPTION


## Summary
Changes the width of private use area (PUA) characters to be 1 rather than 0.

 Fixes GothenburgBitFactory/taskwarrior#3992.

## Problem
Zero-width PUA characters caused offsets when included in taskwarrior reports.

## Example
Before:
<img width="469" height="113" alt="before" src="https://github.com/user-attachments/assets/e7aa5595-5b65-4420-9b1d-4d52412afea4" />
After:
<img width="447" height="111" alt="after" src="https://github.com/user-attachments/assets/f2a04360-b4bf-4f4e-bbc8-66428cf36dc5" />

## Changes
- Changed the width for private use area characters to be 1 rather than 0.
- Added tests to ensure the width of PUA characters.